### PR TITLE
[FEAT] 공통 응답 구조와 전역 예외 처리를 구현합니다

### DIFF
--- a/src/main/java/org/appjam/bongbaek/global/api/ApiResponse.java
+++ b/src/main/java/org/appjam/bongbaek/global/api/ApiResponse.java
@@ -1,0 +1,27 @@
+package org.appjam.bongbaek.global.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.appjam.bongbaek.global.common.ErrorCode;
+import org.appjam.bongbaek.global.common.SuccessCode;
+
+public record ApiResponse<T>(
+        boolean success,
+        int status,
+        String message,
+        @JsonInclude(value = JsonInclude.Include.NON_NULL)
+        T data
+) {
+    // response body 없는 버전
+    public static <T> ApiResponse<T> success(SuccessCode successCode) {
+        return new ApiResponse<>(successCode.getSuccess(), successCode.getStatus().value(), successCode.getMessage(), null);
+    }
+
+    // response body 있는 버전
+    public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
+        return new ApiResponse<>(successCode.getSuccess(), successCode.getStatus().value(), successCode.getMessage(), data);
+    }
+
+    public static <T> ApiResponse<T> failure(ErrorCode failureCode) {
+        return new ApiResponse<>(failureCode.getSuccess(), failureCode.getStatus().value(), failureCode.getMessage(), null);
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
@@ -1,0 +1,39 @@
+package org.appjam.bongbaek.global.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonErrorCode implements ErrorCode {
+    // 404 Not Found
+    INVALID_URL_ERROR(false, HttpStatus.NOT_FOUND, "잘못된 URL 입니다."),
+
+    // 405 Method Not Allowed
+    METHOD_NOT_ALLOWED_ERROR(false, HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),
+
+    // 500 Server Error
+    INTERNAL_SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, "서버 측 에러입니다.");
+
+    private final boolean success;
+    private final HttpStatus status;
+    private final String errorMessage;
+
+    CommonErrorCode(boolean success, HttpStatus httpStatus, String errorMessage) {
+        this.success = success;
+        this.status = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public boolean getSuccess() {
+        return this.success;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
@@ -3,6 +3,15 @@ package org.appjam.bongbaek.global.common;
 import org.springframework.http.HttpStatus;
 
 public enum CommonErrorCode implements ErrorCode {
+    // 400 Bad Request
+    BAD_REQUEST(false, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    // 401 Unauthorized
+    UNAUTHORIZED(false, HttpStatus.UNAUTHORIZED,"인증에 실패했습니다."),
+
+    // 403 Forbidden
+    FORBIDDEN(false, HttpStatus.FORBIDDEN,"권한이 없습니다."),
+
     // 404 Not Found
     INVALID_URL_ERROR(false, HttpStatus.NOT_FOUND, "잘못된 URL 입니다."),
 

--- a/src/main/java/org/appjam/bongbaek/global/common/CommonSuccessCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/CommonSuccessCode.java
@@ -1,0 +1,36 @@
+package org.appjam.bongbaek.global.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommonSuccessCode implements SuccessCode {
+    // 200 Ok
+    OK(true, HttpStatus.OK, "요청이 성공했습니다."),
+
+    // 201 Created
+    CREATED(true, HttpStatus.CREATED, "생성되었습니다.");
+
+    private final boolean success;
+    private final HttpStatus status;
+    private final String successMessage;
+
+    CommonSuccessCode(boolean success, HttpStatus httpStatus, String successMessage) {
+        this.success = success;
+        this.status = httpStatus;
+        this.successMessage = successMessage;
+    }
+
+    @Override
+    public boolean getSuccess() {
+        return success;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return successMessage;
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/common/ErrorCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/ErrorCode.java
@@ -1,0 +1,9 @@
+package org.appjam.bongbaek.global.common;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    boolean getSuccess();
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/org/appjam/bongbaek/global/common/SuccessCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/SuccessCode.java
@@ -1,0 +1,9 @@
+package org.appjam.bongbaek.global.common;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCode {
+    boolean getSuccess();
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/org/appjam/bongbaek/global/exception/CustomException.java
+++ b/src/main/java/org/appjam/bongbaek/global/exception/CustomException.java
@@ -1,0 +1,14 @@
+package org.appjam.bongbaek.global.exception;
+
+import lombok.Getter;
+import org.appjam.bongbaek.global.common.ErrorCode;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/appjam/bongbaek/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package org.appjam.bongbaek.global.exception;
+
+import org.appjam.bongbaek.global.api.ApiResponse;
+import org.appjam.bongbaek.global.common.CommonErrorCode;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ApiResponse<Void> handleSampleException(CustomException e) {
+        return ApiResponse.failure(e.getErrorCode());
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ApiResponse<Void> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        return ApiResponse.failure(CommonErrorCode.INVALID_URL_ERROR);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ApiResponse<Void> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        return ApiResponse.failure(CommonErrorCode.METHOD_NOT_ALLOWED_ERROR);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<Void> handleInternalServerException(Exception e) {
+        return ApiResponse.failure(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/appjam/bongbaek/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package org.appjam.bongbaek.global.exception;
 
+import com.google.protobuf.Api;
 import org.appjam.bongbaek.global.api.ApiResponse;
 import org.appjam.bongbaek.global.common.CommonErrorCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,22 +13,30 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ApiResponse<Void> handleSampleException(CustomException e) {
-        return ApiResponse.failure(e.getErrorCode());
+    public ResponseEntity<ApiResponse<Void>> handleSampleException(CustomException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.failure(e.getErrorCode()));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ApiResponse<Void> handleNoHandlerFoundException(NoHandlerFoundException e) {
-        return ApiResponse.failure(CommonErrorCode.INVALID_URL_ERROR);
+    public ResponseEntity<ApiResponse<Void>> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        return ResponseEntity
+                .status(CommonErrorCode.INVALID_URL_ERROR.getStatus())
+                .body(ApiResponse.failure(CommonErrorCode.INVALID_URL_ERROR));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ApiResponse<Void> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-        return ApiResponse.failure(CommonErrorCode.METHOD_NOT_ALLOWED_ERROR);
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity
+                .status(CommonErrorCode.METHOD_NOT_ALLOWED_ERROR.getStatus())
+                .body(ApiResponse.failure(CommonErrorCode.METHOD_NOT_ALLOWED_ERROR));
     }
 
     @ExceptionHandler(Exception.class)
-    public ApiResponse<Void> handleInternalServerException(Exception e) {
-        return ApiResponse.failure(CommonErrorCode.INTERNAL_SERVER_ERROR);
+    public ResponseEntity<ApiResponse<Void>> handleInternalServerException(Exception e) {
+        return ResponseEntity
+                .status(CommonErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.failure(CommonErrorCode.INTERNAL_SERVER_ERROR));
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #2 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- GlobalHandler (예외 핸들러)와 ApiResponse (공통 응답)을 구현했습니다. 
 1. 응답 메시지에 대해 enum 파일로 CommonErrorCode, CommonSuccessCode를 사용했습니다.
 2. ApiResponse는 success, failure 로 구분하여 예외 응답도 ApiResponse로 처리하게 구성했습니다.
 3. 후도메인 확장에 유연하도록 ErrorCode 와 SuccessCode를 인터페이스로 만들었습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] ErrorCode 작성
- [x] SuccessCode 작성
- [x] GlobalHandler 작성
- [x] CustomException 작성
- [x] ApiResponse로 공통 응답 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 추가한 파일 구조도
![image](https://github.com/user-attachments/assets/13a14d6d-18fc-40c8-b6c6-3e4e983d104a)

- 예외 처리 응답 코드 예시
![image](https://github.com/user-attachments/assets/682c2e29-5af0-4415-889c-c8b0925f1e13)

- return 방법
![image](https://github.com/user-attachments/assets/efdd5277-8c50-42ad-99b4-9b800983a9d2)
ResponseEntity를 통해 실질적인 HTTP 상태 코드를 넣고 body 값에 ApiResponse를 넣어 응답합니다.

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- API 명세서 공통 응답에 맞게 @JsonInclude를 사용하여 data가 Null이면 응답에서 없어지도록 처리했습니다~
- 공통 응답 코드에 대해 바꾸고 싶은 것, 수정해야 하는 것 모두 말씀해주세요!! 
