### PR TITLE
[FEAT] 경조사 정보 생성 및 조회 기능 구현

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
@@ -6,16 +6,29 @@ import java.util.UUID;
 
 import jakarta.validation.Valid;
 import org.appjam.bongbaek.domain.event.code.EventSuccessCode;
+import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventDeleteRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventUpdateRequestDto;
+import org.appjam.bongbaek.domain.event.dto.request.EventWriteDto;
+import org.appjam.bongbaek.domain.event.dto.response.CostProposalResponseDto;
 import org.appjam.bongbaek.domain.event.dto.response.EventDetailResponseDto;
 import org.appjam.bongbaek.domain.event.dto.response.EventHomeResponseDto;
-import org.appjam.bongbaek.domain.event.exception.InvalidUUIDFormatException;
+import org.appjam.bongbaek.domain.event.dto.response.EventListDto;
 import org.appjam.bongbaek.domain.event.service.EventService;
 import org.appjam.bongbaek.global.api.ApiResponse;
-import org.springframework.web.bind.annotation.*;
+import org.appjam.bongbaek.global.common.CommonSuccessCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +38,57 @@ import lombok.RequiredArgsConstructor;
 public class EventController {
 
     private final EventService eventService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createEvent(
+            @RequestHeader(name = "memberId") final String memberId,
+            @RequestBody @Valid final EventWriteDto eventWriteDto
+    ) {
+        UUID testId = UUID.fromString(memberId);
+        eventService.createEventInfo(testId, eventWriteDto);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(CommonSuccessCode.CREATED));
+    }
+
+    @GetMapping(path = "/history/{page}")
+    public ResponseEntity<ApiResponse<EventListDto>> getEventHistory(
+            @RequestHeader(name = "memberId") final String memberId,
+            @PathVariable(name = "page") int page,
+            @RequestParam(name = "category", required = false) String category,
+            @RequestParam(name = "attended", required = false) Boolean attended
+    ) {
+        UUID testId = UUID.fromString(memberId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(CommonSuccessCode.OK,
+                        eventService.getEventHistory(testId, page, category, attended)));
+    }
+
+    @GetMapping(path = "/upcoming/{page}")
+    public ResponseEntity<ApiResponse<EventListDto>> getUpcomingEvents(
+            @RequestHeader(name = "memberId") final String memberId,
+            @PathVariable(name = "page") final int page,
+            @RequestParam(name = "category", required = false) final String category
+    ) {
+        UUID testId = UUID.fromString(memberId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(CommonSuccessCode.OK,
+                        eventService.getUpcomingEvents(testId, page, category)));
+    }
+
+    @PostMapping(path = "/cost")
+    public ResponseEntity<ApiResponse<CostProposalResponseDto>> createEventCost(
+            @RequestHeader(name = "memberId") final String memberId,
+            @RequestBody @Valid final CostProposalRequestDto costProposalRequestDto
+    ){
+        UUID testId = UUID.fromString(memberId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(CommonSuccessCode.OK,
+                        eventService.getCostProposal(testId, costProposalRequestDto)));
+    }
 
     @GetMapping(path = "/{eventId}")
     public ResponseEntity<ApiResponse<EventDetailResponseDto>> getEventByEventId(

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/common/LocationInfo.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/common/LocationInfo.java
@@ -19,10 +19,6 @@ public record LocationInfo(
 	}
 
 	public static LocationInfo from(String location) {
-		return new LocationInfo(
-				location,
-				null,
-				null,
-				null);
+		return new LocationInfo(location, null, null, null);
 	}
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/request/CostProposalRequestDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/request/CostProposalRequestDto.java
@@ -1,0 +1,15 @@
+package org.appjam.bongbaek.domain.event.dto.request;
+
+import org.appjam.bongbaek.domain.event.dto.common.HighAccuracy;
+import org.appjam.bongbaek.domain.event.dto.common.LocationInfo;
+
+import jakarta.validation.Valid;
+
+public record CostProposalRequestDto(
+		String category,
+		String relationship,
+		boolean attended,
+		LocationInfo locationInfo,
+		@Valid HighAccuracy highAccuracy
+		) {
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/request/EventWriteDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/request/EventWriteDto.java
@@ -1,0 +1,38 @@
+package org.appjam.bongbaek.domain.event.dto.request;
+
+import org.appjam.bongbaek.domain.event.entity.Category;
+import org.appjam.bongbaek.domain.event.entity.Event;
+import org.appjam.bongbaek.domain.event.entity.Relationship;
+import org.appjam.bongbaek.domain.event.dto.common.EventInfo;
+import org.appjam.bongbaek.domain.event.dto.common.HighAccuracy;
+import org.appjam.bongbaek.domain.event.dto.common.HostInfo;
+import org.appjam.bongbaek.domain.event.dto.common.LocationInfo;
+import org.appjam.bongbaek.domain.member.entity.Member;
+
+import jakarta.validation.Valid;
+
+public record EventWriteDto(
+		@Valid HostInfo hostInfo,
+		@Valid EventInfo eventInfo,
+		@Valid LocationInfo locationInfo,
+		@Valid HighAccuracy highAccuracy
+) {
+	public Event toEntity(Member member) {
+		return Event.builder()
+				.hostName(hostInfo.hostName())
+				.hostNickname(hostInfo.hostNickname())
+				.contactFrequency(highAccuracy.contactFrequency())
+				.meetFrequency(highAccuracy.meetFrequency())
+				.eventCategory(Category.of(eventInfo.eventCategory()))
+				.relationship(Relationship.of(eventInfo.relationship()))
+				.eventDate(eventInfo.eventDate())
+				.cost(eventInfo.cost())
+				.attended(eventInfo.isAttend())
+				.location(locationInfo.location())
+				.address(locationInfo.address())
+				.latitude(locationInfo.latitude())
+				.longitude(locationInfo.longitude())
+				.member(member)
+				.build();
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/response/CostProposalResponseDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/response/CostProposalResponseDto.java
@@ -1,0 +1,54 @@
+package org.appjam.bongbaek.domain.event.dto.response;
+
+import org.appjam.bongbaek.domain.event.service.util.vo.CostParamInfo;
+import org.appjam.bongbaek.domain.event.service.util.vo.RangeInfo;
+
+public record CostProposalResponseDto(
+		int cost,
+		CostRange range,
+		String category,
+		String location,
+		ProposalParams params
+) {
+	public static CostProposalResponseDto of(
+			int cost,
+			RangeInfo rangeInfo,
+			String category,
+			String location,
+			CostParamInfo costParams
+	) {
+		return new CostProposalResponseDto(
+				cost,
+				CostRange.of(rangeInfo),
+				category,
+				location,
+				ProposalParams.of(costParams));
+	}
+
+	private record CostRange(int min, int max) {
+		private static CostRange of(RangeInfo rangeInfo) {
+			return new CostRange(rangeInfo.min(), rangeInfo.max());
+		}
+	}
+
+	private record ProposalParams(
+			int age,
+			String income,
+			String category,
+			String relationship,
+			boolean attended,
+			int contactFrequency,
+			int meetFrequency
+	) {
+		private static ProposalParams of(CostParamInfo costParams) {
+			return new ProposalParams(
+					costParams.age(),
+					costParams.income(),
+					costParams.category(),
+					costParams.relationship(),
+					costParams.attended(),
+					costParams.contactFrequency(),
+					costParams.meetFrequency());
+		}
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventListDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventListDto.java
@@ -1,0 +1,34 @@
+package org.appjam.bongbaek.domain.event.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.appjam.bongbaek.domain.event.entity.Event;
+import org.appjam.bongbaek.domain.event.dto.common.EventInfo;
+import org.appjam.bongbaek.domain.event.dto.common.HostInfo;
+import org.springframework.data.domain.Slice;
+
+public record EventListDto(
+		List<EventListElement> events,
+		int currentPage,
+		boolean isLast
+) {
+	public static EventListDto of(Slice<Event> events){
+		List<EventListElement> elements = events.getContent().stream()
+				.map(EventListElement::from)
+				.toList();
+
+		return new EventListDto(elements, events.getNumber(), events.isLast());
+	}
+
+	private record EventListElement(UUID eventId, HostInfo hostInfo, EventInfo eventInfo) {
+		private static EventListElement from(Event event) {
+			return new EventListElement(event.getEventId(), HostInfo.from(event),
+					EventInfo.from(
+							event.getEventCategory().getDescription(),
+							event.getRelationship().getDescription(),
+							event.getCost(),
+							event.getEventDate(),null));
+		}
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/entity/Relationship.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/entity/Relationship.java
@@ -8,14 +8,15 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Relationship {
-	FAMILY("가족/친척"),
-	FRIEND("친구"),
-	COWORKER("직장"),
-	ALUMNI("선후배"),
-	NEIGHBOR("이웃"),
-	ETC("기타");
+	FAMILY("가족/친척", 1.7f),
+	FRIEND("친구", 1.7f),
+	COWORKER("직장", 1.3f),
+	ALUMNI("선후배", 1.3f),
+	NEIGHBOR("이웃", 1.2f),
+	ETC("기타", 1.3f);
 
 	private final String description;
+	private final float score;
 
 	public static Relationship of(String description) {
 		return Arrays.stream(Relationship.values())

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EventRepository extends JpaRepository<Event, UUID> {
+public interface EventRepository extends JpaRepository<Event, UUID>, EventSearchRepository{
 
     List<Event> findTop3ByEventDateGreaterThanEqualAndMemberMemberIdOrderByEventDateAsc(LocalDate now, UUID member_memberId); // TO DO: jwt 발급 시 사용
 

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
@@ -1,0 +1,14 @@
+package org.appjam.bongbaek.domain.event.repository;
+
+import java.util.UUID;
+
+import org.appjam.bongbaek.domain.event.entity.Category;
+import org.appjam.bongbaek.domain.event.entity.Event;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface EventSearchRepository {
+	Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(UUID memberId, Category category, Boolean attended, Pageable pageable);
+
+	Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(UUID memberId, Category category, Pageable pageable);
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -1,0 +1,93 @@
+package org.appjam.bongbaek.domain.event.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.appjam.bongbaek.domain.event.entity.Category;
+import org.appjam.bongbaek.domain.event.entity.Event;
+import org.appjam.bongbaek.domain.event.entity.QEvent;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EventSearchRepositoryImpl implements EventSearchRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(
+			UUID memberId,
+			Category category,
+			Boolean attended,
+			Pageable pageable
+	) {
+		QEvent qEvent = QEvent.event;
+		int pageSize = pageable.getPageSize();
+
+		List<Event> events = queryFactory.selectFrom(qEvent)
+				.where(
+						qEvent.member.memberId.eq(memberId),
+						qEvent.eventDate.before(LocalDate.now()),
+						categoryEqual(category),
+						attendedEqual(attended)
+				)
+				.orderBy(qEvent.eventDate.desc())
+				.offset(pageable.getOffset())
+				.limit(pageSize + 1)
+				.fetch();
+
+		boolean hasNext = events.size() > pageSize;
+		if (hasNext) {
+			events.remove(pageSize);
+		}
+
+		return new SliceImpl<Event>(events, pageable, hasNext);
+	}
+
+	@Override
+	public Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(UUID memberId, Category category,
+			Pageable pageable) {
+		QEvent qEvent = QEvent.event;
+		int pageSize = pageable.getPageSize();
+
+		List<Event> events = queryFactory.selectFrom(qEvent)
+				.where(
+						qEvent.member.memberId.eq(memberId),
+						qEvent.eventDate.after(LocalDate.now()),
+						categoryEqual(category)
+				)
+				.orderBy(qEvent.eventDate.asc())
+				.offset(pageable.getOffset())
+				.limit(pageSize + 1)
+				.fetch();
+
+		boolean hasNext = events.size() > pageSize;
+		if (hasNext) {
+			events.remove(pageSize);
+		}
+
+		return new SliceImpl<Event>(events, pageable, hasNext);
+	}
+
+	private BooleanExpression categoryEqual(Category category) {
+		if(category == null){
+			return null;
+		}
+		return QEvent.event.eventCategory.eq(category);
+	}
+
+	private BooleanExpression attendedEqual(Boolean attended) {
+		if(attended == null){
+			return null;
+		}
+		return QEvent.event.attended.eq(attended);
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -35,7 +35,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 		List<Event> events = queryFactory.selectFrom(qEvent)
 				.where(
 						qEvent.member.memberId.eq(memberId),
-						qEvent.eventDate.before(LocalDate.now()),
+						qEvent.eventDate.loe(LocalDate.now()),
 						categoryEqual(category),
 						attendedEqual(attended)
 				)
@@ -61,7 +61,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 		List<Event> events = queryFactory.selectFrom(qEvent)
 				.where(
 						qEvent.member.memberId.eq(memberId),
-						qEvent.eventDate.after(LocalDate.now()),
+						qEvent.eventDate.goe(LocalDate.now()),
 						categoryEqual(category)
 				)
 				.orderBy(qEvent.eventDate.asc())

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/MemberRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package org.appjam.bongbaek.domain.event.repository;
+
+import java.util.UUID;
+
+import org.appjam.bongbaek.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
@@ -1,14 +1,26 @@
 package org.appjam.bongbaek.domain.event.service;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 
+import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventUpdateRequestDto;
+import org.appjam.bongbaek.domain.event.dto.request.EventWriteDto;
+import org.appjam.bongbaek.domain.event.dto.response.CostProposalResponseDto;
 import org.appjam.bongbaek.domain.event.dto.response.EventDetailResponseDto;
+import org.appjam.bongbaek.domain.event.dto.response.EventListDto;
+import org.appjam.bongbaek.domain.event.entity.Category;
 import org.appjam.bongbaek.domain.event.exception.NotFoundEventException;
-import org.appjam.bongbaek.domain.event.exception.UnauthorizationException;
+import org.appjam.bongbaek.domain.event.repository.MemberRepository;
+import org.appjam.bongbaek.domain.event.service.util.CostCalculator;
+import org.appjam.bongbaek.domain.event.service.util.RangeCalculator;
+import org.appjam.bongbaek.domain.event.service.util.vo.CostParamInfo;
+import org.appjam.bongbaek.domain.event.service.util.vo.RangeInfo;
+import org.appjam.bongbaek.domain.member.entity.Member;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.transaction.annotation.Transactional;
 import org.appjam.bongbaek.domain.event.dto.response.EventHomeResponseDto;
 import org.appjam.bongbaek.domain.event.entity.Event;
@@ -20,11 +32,51 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class EventService {
+    private static final int PAGE_SIZE = 10;
 
     private final EventRepository eventRepository;
+    private final MemberRepository memberRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
+    public void createEventInfo(final UUID memberId, final EventWriteDto eventWriteDto) {
+        Member memberProxy = memberRepository.getReferenceById(memberId);
+        Event event = eventWriteDto.toEntity(memberProxy);
+        eventRepository.save(event);
+    }
+
+    public EventListDto getEventHistory(final UUID memberId, final int page, final String category,
+            final Boolean attended) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Slice<Event> result = eventRepository.findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(memberId,
+                Category.of(category), attended, pageable);
+
+        return EventListDto.of(result);
+    }
+
+    public EventListDto getUpcomingEvents(final UUID memberId, final int page, final String category) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Slice<Event> result = eventRepository.findUpcomingEventsByMemberIdAndCategoryOrderBy(memberId,
+                Category.of(category), pageable);
+
+        return EventListDto.of(result);
+    }
+
+    public CostProposalResponseDto getCostProposal(UUID memberId, CostProposalRequestDto costProposalRequestDto) {
+        Member member = memberRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
+
+        int cost = CostCalculator.calculateCost(member, costProposalRequestDto);
+
+        RangeInfo range = RangeCalculator.calculateRange(cost);
+
+        CostParamInfo costParams = CostParamInfo.of(member, costProposalRequestDto);
+
+        return CostProposalResponseDto.of(cost, range,
+                costProposalRequestDto.locationInfo().location(),
+                costProposalRequestDto.category(), costParams);
+    }
+
     public EventDetailResponseDto getEventByEventId(UUID eventUUID, UUID memberUUID) {
 
         Event event = eventRepository.findEventByEventIdAndMemberMemberId(eventUUID, memberUUID)
@@ -33,7 +85,7 @@ public class EventService {
         return EventDetailResponseDto.of(event);
     }
 
-    @Transactional(readOnly = true)
+
     public EventHomeResponseDto getEventsForHome(LocalDate now, UUID memberUUID){
 
         List<Event> events = eventRepository.findTop3ByEventDateGreaterThanEqualAndMemberMemberIdOrderByEventDateAsc(now, memberUUID);

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
@@ -12,7 +12,7 @@ import org.appjam.bongbaek.domain.event.dto.response.EventDetailResponseDto;
 import org.appjam.bongbaek.domain.event.dto.response.EventListDto;
 import org.appjam.bongbaek.domain.event.entity.Category;
 import org.appjam.bongbaek.domain.event.exception.NotFoundEventException;
-import org.appjam.bongbaek.domain.event.repository.MemberRepository;
+import org.appjam.bongbaek.domain.member.repository.MemberRepository;
 import org.appjam.bongbaek.domain.event.service.util.CostCalculator;
 import org.appjam.bongbaek.domain.event.service.util.RangeCalculator;
 import org.appjam.bongbaek.domain.event.service.util.vo.CostParamInfo;

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/CostCalculator.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/CostCalculator.java
@@ -1,0 +1,86 @@
+package org.appjam.bongbaek.domain.event.service.util;
+
+import org.appjam.bongbaek.domain.event.dto.common.HighAccuracy;
+import org.appjam.bongbaek.domain.event.entity.Category;
+import org.appjam.bongbaek.domain.event.entity.Relationship;
+import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
+import org.appjam.bongbaek.domain.member.entity.IncomeType;
+import org.appjam.bongbaek.domain.member.entity.Member;
+
+public class CostCalculator {
+	private static final int UNIT_AMOUNT = 10000;
+
+	public static int calculateCost(Member member, CostProposalRequestDto costProposalRequestDto) {
+		// 경조사 종류에 따른 기본금
+		Category category = Category.of(costProposalRequestDto.category());
+		int defaultCost = category.getDefaultCost();
+
+		// 나이 계수
+		float ageCoefficient = calculateAgeCoefficient(member.getAge());
+
+		// 수입 계수
+		float incomeCoefficient = calculateIncomeCoefficient(member.getMemberIncome());
+
+		// 경조사 대상과의 관계
+		Relationship relationship = Relationship.of(costProposalRequestDto.relationship());
+		float relationshipCoefficient = relationship.getScore();
+
+		// 참석 여부
+		float attendedCoefficient = calculateAttendedCoefficient(costProposalRequestDto.attended());
+
+		// 만남 빈도, 연락 빈도
+		HighAccuracy highAccuracy = costProposalRequestDto.highAccuracy();
+		int contactFrequency = highAccuracy.contactFrequency();
+		int meetFrequency = highAccuracy.meetFrequency();
+
+		// 금액 산정
+		float cost = defaultCost * ageCoefficient * incomeCoefficient * relationshipCoefficient *
+				(1 + (attendedCoefficient + meetFrequency + contactFrequency) / 100);
+
+		// 금액 보정을 위한 올림 처리
+		int result = (int)Math.ceil(cost / UNIT_AMOUNT);
+
+		// 장례식인 경우 금액을 홀수로 조정
+		if (category.equals(Category.FUNERAL) && result % 2 == 0) {
+			result = result - 1;
+		}
+
+		// 만원 단위로 금액 조정
+		return result * UNIT_AMOUNT;
+	}
+
+	private static float calculateAgeCoefficient(int age) {
+		// 20대 이하면 0.8
+		if (age <= 29) {
+			return 0.8f;
+		}
+		// 40대 이상이면 1.2
+		if (age >= 40) {
+			return 1.2f;
+		}
+		// 30대면 1
+		return 1.0f;
+	}
+
+	private static float calculateIncomeCoefficient(IncomeType incomeType) {
+		// 수입이 200 이상이면 1.1
+		if (incomeType == IncomeType.OVER200) {
+			return 1.1f;
+		}
+		// 수입이 200 이하면 0.8
+		if (incomeType == IncomeType.UNDER200) {
+			return 0.8f;
+		}
+		// 수입이 없으면 0.7
+		return 0.7f;
+	}
+
+	private static float calculateAttendedCoefficient(boolean attended) {
+		// 참석인 경우 2
+		if (attended) {
+			return 2;
+		}
+		// 불참인 경우 1
+		return 1;
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/CostCalculator.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/CostCalculator.java
@@ -10,6 +10,22 @@ import org.appjam.bongbaek.domain.member.entity.Member;
 public class CostCalculator {
 	private static final int UNIT_AMOUNT = 10000;
 
+	// 나이 계수 상수
+	private static final float AGE_COEFFICIENT_YOUNG = 0.8f;
+	private static final float AGE_COEFFICIENT_MIDDLE = 1.0f;
+	private static final float AGE_COEFFICIENT_OLD = 1.2f;
+	private static final int AGE_THRESHOLD_YOUNG = 29;
+	private static final int AGE_THRESHOLD_OLD = 40;
+
+	// 수입 계수 상수
+	private static final float INCOME_COEFFICIENT_HIGH = 1.1f;
+	private static final float INCOME_COEFFICIENT_LOW = 0.8f;
+	private static final float INCOME_COEFFICIENT_NONE = 0.7f;
+
+	// 참석 계수 상수
+	private static final float ATTENDED_COEFFICIENT_YES = 2.0f;
+	private static final float ATTENDED_COEFFICIENT_NO = 1.0f;
+
 	public static int calculateCost(Member member, CostProposalRequestDto costProposalRequestDto) {
 		// 경조사 종류에 따른 기본금
 		Category category = Category.of(costProposalRequestDto.category());
@@ -51,36 +67,36 @@ public class CostCalculator {
 
 	private static float calculateAgeCoefficient(int age) {
 		// 20대 이하면 0.8
-		if (age <= 29) {
-			return 0.8f;
+		if (age <= AGE_THRESHOLD_YOUNG) {
+			return AGE_COEFFICIENT_YOUNG;
 		}
 		// 40대 이상이면 1.2
-		if (age >= 40) {
-			return 1.2f;
+		if (age >= AGE_THRESHOLD_OLD) {
+			return AGE_COEFFICIENT_OLD;
 		}
 		// 30대면 1
-		return 1.0f;
+		return AGE_COEFFICIENT_MIDDLE;
 	}
 
 	private static float calculateIncomeCoefficient(IncomeType incomeType) {
 		// 수입이 200 이상이면 1.1
 		if (incomeType == IncomeType.OVER200) {
-			return 1.1f;
+			return INCOME_COEFFICIENT_HIGH;
 		}
 		// 수입이 200 이하면 0.8
 		if (incomeType == IncomeType.UNDER200) {
-			return 0.8f;
+			return INCOME_COEFFICIENT_LOW;
 		}
 		// 수입이 없으면 0.7
-		return 0.7f;
+		return INCOME_COEFFICIENT_NONE;
 	}
 
 	private static float calculateAttendedCoefficient(boolean attended) {
 		// 참석인 경우 2
 		if (attended) {
-			return 2;
+			return ATTENDED_COEFFICIENT_YES;
 		}
 		// 불참인 경우 1
-		return 1;
+		return ATTENDED_COEFFICIENT_NO;
 	}
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/RangeCalculator.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/RangeCalculator.java
@@ -1,0 +1,18 @@
+package org.appjam.bongbaek.domain.event.service.util;
+
+import org.appjam.bongbaek.domain.event.service.util.vo.RangeInfo;
+
+public class RangeCalculator {
+	public static RangeInfo calculateRange(int cost) {
+		if (cost <= 30_000) {
+			return new RangeInfo(10_000, 50_000);
+		}
+		if (cost <= 100_000) {
+			return new RangeInfo(cost - 20_000, cost + 20_000);
+		}
+		if (cost <= 300_000) {
+			return new RangeInfo(cost - 30_000, cost + 30_000);
+		}
+		return new RangeInfo(cost - 50_000, cost + 50_000);
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/vo/CostParamInfo.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/vo/CostParamInfo.java
@@ -1,0 +1,26 @@
+package org.appjam.bongbaek.domain.event.service.util.vo;
+
+import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
+import org.appjam.bongbaek.domain.member.entity.Member;
+
+public record CostParamInfo(
+		int age,
+		String income,
+		String category,
+		String relationship,
+		boolean attended,
+		int contactFrequency,
+		int meetFrequency
+) {
+	public static CostParamInfo of(Member member, CostProposalRequestDto costProposalRequestDto) {
+		return new CostParamInfo(
+				member.getAge(),
+				member.getMemberIncome().getDescription(),
+				costProposalRequestDto.category(),
+				costProposalRequestDto.relationship(),
+				costProposalRequestDto.attended(),
+				costProposalRequestDto.highAccuracy().contactFrequency(),
+				costProposalRequestDto.highAccuracy().meetFrequency()
+		);
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/vo/RangeInfo.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/vo/RangeInfo.java
@@ -1,0 +1,4 @@
+package org.appjam.bongbaek.domain.event.service.util.vo;
+
+public record RangeInfo(int min, int max) {
+}

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/IncomeType.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/IncomeType.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum IncomeType {
 	OVER200("200만원 이상"),
-	UNDER200("200만원 이하");
+	UNDER200("200만원 이하"),
+	NONE("없음");
 
 	private final String description;
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package org.appjam.bongbaek.domain.member.entity;
 
 import java.time.LocalDate;
+import java.time.Period;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -47,5 +48,9 @@ public class Member {
 		this.memberIncome = memberIncome;
 		this.appleId = appleId;
 		this.kakaoId = kakaoId;
+	}
+
+	public int getAge(){
+		return Period.between(this.memberBirthday, LocalDate.now()).getYears();
 	}
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberRepository.java
@@ -1,4 +1,4 @@
-package org.appjam.bongbaek.domain.event.repository;
+package org.appjam.bongbaek.domain.member.repository;
 
 import java.util.UUID;
 

--- a/src/main/java/org/appjam/bongbaek/global/config/QuerydslConfig.java
+++ b/src/main/java/org/appjam/bongbaek/global/config/QuerydslConfig.java
@@ -1,0 +1,22 @@
+package org.appjam.bongbaek.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+	@PersistenceContext
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(() -> entityManager);
+	}
+}

--- a/src/main/java/org/appjam/bongbaek/global/config/SecurityConfig.java
+++ b/src/main/java/org/appjam/bongbaek/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.appjam.bongbaek.global.jwt.util.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -30,6 +31,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/api/v1/events/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #14 #20 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 경조사 정보 생성 및 조회에 대한 기능을 구현하였습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 경조사 생성 기능 구현
- [x] 더보기에서의 경조사 조회 기능 구현
- [x] 참석 예정인 경조사에 대해 경조사 종류에 따라 오름차순 정렬
- [x] 기록하기에서의 경조사 조회 기능 구현
- [x] 이미 지난 경조사들에 대해 경조사 종류와 참석 여부에 따라 내림차순 정렬
- [x] 10개 단위로 무한 스크롤 적용
- [x] 경조사 비용 계산 및 추천 기능 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 경조사 생성
<img width="1478" alt="스크린샷 2025-07-09 오후 4 46 28" src="https://github.com/user-attachments/assets/978afd96-f2f9-4529-b0a2-397d0f3aac6a" />
- 더보기에서의 경조사 조회
<img width="1480" alt="스크린샷 2025-07-09 오후 4 46 52" src="https://github.com/user-attachments/assets/74673ba1-af0b-4013-b033-28b213427884" />
- 기록하기에서의 경조사 조회
<img width="1492" alt="스크린샷 2025-07-09 오후 4 53 02" src="https://github.com/user-attachments/assets/4523903b-1e4a-433d-9262-37feb5273e74" />
- 경조사 금액 추천값 반환
<img width="1481" alt="스크린샷 2025-07-09 오후 4 53 18" src="https://github.com/user-attachments/assets/2b53864a-1f8c-4b1b-982b-560ae6ca1837" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 일단 빠른 가배포를 위해 예외처리 같은 건 과감하게 미루게 되었습니다.
- 로그인 로직이 아직 통합되지 않아서 헤더의 `memberId`로 토큰을 임시 대체합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이벤트 생성, 이벤트 내역 조회, 예정 이벤트 조회, 비용 제안 요청 등 이벤트 관련 신규 API 엔드포인트가 추가되었습니다.
  * 이벤트 생성 및 비용 제안 요청을 위한 새로운 데이터 입력 양식이 도입되었습니다.
  * 이벤트 내역 및 예정 이벤트의 페이지네이션 지원이 추가되었습니다.
  * 이벤트 비용 산출 및 범위 제안 기능이 제공됩니다.

* **기타 개선**
  * 관계 및 소득 유형 등 일부 데이터 타입이 확장되었습니다.
  * 멤버 나이 계산 등 편의 메서드가 추가되었습니다.
  * 일부 엔드포인트가 인증 없이 접근 가능하도록 보안 설정이 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->