### PR TITLE
[FEAT] 토큰 재발급 api 구현

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -3,13 +3,13 @@ package org.appjam.bongbaek.domain.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.appjam.bongbaek.global.oauth.PrincipalHandler;
 import org.appjam.bongbaek.domain.member.dto.LoginRequest;
 import org.appjam.bongbaek.domain.member.dto.LoginResponse;
 import org.appjam.bongbaek.domain.member.dto.SignUpRequest;
 import org.appjam.bongbaek.domain.member.service.MemberService;
 import org.appjam.bongbaek.global.api.ApiResponse;
 import org.appjam.bongbaek.global.common.CommonSuccessCode;
+import org.appjam.bongbaek.global.jwt.dto.TokenResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -47,5 +47,16 @@ public class MemberController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(CommonSuccessCode.SIGNUP_COMPLETED, loginResponse));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.")
+    @PostMapping("/member/reissue")
+    public ResponseEntity<ApiResponse<TokenResponse>> reissueTokens(
+            @RequestHeader("refreshToken") final String refreshToken
+    ) {
+        TokenResponse tokenResponse = memberService.reissueTokens(refreshToken);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(CommonSuccessCode.TOKEN_REISSUED, tokenResponse));
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.appjam.bongbaek.domain.member.dto.LoginRequest;
 import org.appjam.bongbaek.domain.member.dto.LoginResponse;
+import org.appjam.bongbaek.domain.member.dto.ReissueRequest;
 import org.appjam.bongbaek.domain.member.dto.SignUpRequest;
 import org.appjam.bongbaek.domain.member.service.MemberService;
 import org.appjam.bongbaek.global.api.ApiResponse;
@@ -52,9 +53,9 @@ public class MemberController {
     @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.")
     @PostMapping("/member/reissue")
     public ResponseEntity<ApiResponse<TokenResponse>> reissueTokens(
-            @RequestHeader("refreshToken") final String refreshToken
-    ) {
-        TokenResponse tokenResponse = memberService.reissueTokens(refreshToken);
+            @RequestBody final ReissueRequest reissueRequest
+            ) {
+        TokenResponse tokenResponse = memberService.reissueTokens(reissueRequest.refreshToken());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(CommonSuccessCode.TOKEN_REISSUED, tokenResponse));

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/ReissueRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/ReissueRequest.java
@@ -1,0 +1,10 @@
+package org.appjam.bongbaek.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReissueRequest(
+        @Schema(description = "리프레쉬 토큰", example = "토큰 재발급을 위한 리프레쉬 토큰")
+        String refreshToken
+) {
+}
+

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -80,7 +80,7 @@ public class MemberService {
 
         UUID memberId = jwtParser.getUserFromJwt(refreshToken);
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(CommonErrorCode.NOT_FOUND_MEMBER));
+                .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
 
         return generateTokensForMember(member);
     }

--- a/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
@@ -15,6 +15,7 @@ public enum CommonErrorCode implements ErrorCode {
     UNAUTHORIZED_MALFORMED_JWT(false, HttpStatus.UNAUTHORIZED, "JWT 형식이 올바르지 않습니다."),
     UNAUTHORIZED_EXPIRATION_JWT_EXCEPTION(false, HttpStatus.UNAUTHORIZED, "JWT가 만료되었습니다."),
     UNAUTHORIZED_UNSUPPORTED_JWT(false, HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT입니다."),
+    INVALID_REFRESH_TOKEN(false, HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않거나 만료되었습니다."),
 
     // 403 Forbidden
     FORBIDDEN(false, HttpStatus.FORBIDDEN,"권한이 없습니다."),
@@ -22,6 +23,7 @@ public enum CommonErrorCode implements ErrorCode {
     // 404 Not Found
     INVALID_URL_ERROR(false, HttpStatus.NOT_FOUND, "잘못된 URL 입니다."),
     MEMBER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED_ERROR(false, HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),

--- a/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
@@ -23,7 +23,6 @@ public enum CommonErrorCode implements ErrorCode {
     // 404 Not Found
     INVALID_URL_ERROR(false, HttpStatus.NOT_FOUND, "잘못된 URL 입니다."),
     MEMBER_NOT_FOUND(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    NOT_FOUND_MEMBER(false, HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED_ERROR(false, HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP method 요청입니다."),

--- a/src/main/java/org/appjam/bongbaek/global/common/CommonSuccessCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/CommonSuccessCode.java
@@ -15,7 +15,10 @@ public enum CommonSuccessCode implements SuccessCode {
     ACCEPTED(true, HttpStatus.ACCEPTED, "회원가입을 진행해주세요."),
 
     // 201 Created for signup
-    SIGNUP_COMPLETED(true, HttpStatus.CREATED, "회원가입이 완료되었습니다.");
+    SIGNUP_COMPLETED(true, HttpStatus.CREATED, "회원가입이 완료되었습니다."),
+
+    // 200 OK for token reissue
+    TOKEN_REISSUED(true, HttpStatus.OK, "토큰이 재발급되었습니다.");
 
     private final boolean success;
     private final HttpStatus status;

--- a/src/main/java/org/appjam/bongbaek/global/config/AuthWhiteList.java
+++ b/src/main/java/org/appjam/bongbaek/global/config/AuthWhiteList.java
@@ -27,5 +27,6 @@ public class AuthWhiteList {
             // 인증 관련 API
             "/api/v1/oauth/kakao",
             "/api/v1/member/profile",
+            "/api/v1/member/reissue",
     };
 }

--- a/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtProvider.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtProvider.java
@@ -1,6 +1,5 @@
 package org.appjam.bongbaek.global.jwt.util;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtValidator.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtValidator.java
@@ -31,4 +31,16 @@ public class JwtValidator {
             throw new CustomException(CommonErrorCode.UNAUTHORIZED_MALFORMED_JWT);
         }
     }
+
+    public void validateRefreshToken(String refreshToken) {
+        try {
+            if (validateToken(refreshToken) != JwtValidationType.VALID_JWT) {
+                throw new CustomException(CommonErrorCode.INVALID_REFRESH_TOKEN);
+            }
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(CommonErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #22 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 토큰 재발급 관련 api를 구현하였습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] while list에 reissue 추가
- [x] reissue 관련 성공, 에러 부분 추가
- [x] refresh token 검증 로직 추가
- [x] reissue 관련 service, controller 부분 추가

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
<img width="1896" height="1398" alt="image" src="https://github.com/user-attachments/assets/3c2d9354-8c13-4548-9432-11878b72ebfe" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 이전에 @CookieValue 를 사용해 받도록 해두었더니 테스트를 할 때에 요청값에선 쿠키를 정확히 보내고 있지만, 받을 때 쿠키 값을 받지 못해 [org.springframework.web.bind.missingrequestcookieexception: required cookie 'refreshtoken' for method parameter type string is not present] 가 뜨는 현상이 계속 되었습니다. 그래서 우선 requestheader로 refreshtoken 값을 받도록 해두었습니다..! 혹시 이 부분에 대해서 해결책이나, 다른 방법이 있다면 알려주시면 바로 반영해보겠습니다 😭

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 리프레시 토큰을 이용한 토큰 재발급 API가 추가되었습니다. 이제 `/member/reissue` 엔드포인트를 통해 토큰을 재발급받을 수 있습니다.

* **버그 수정**
  * 리프레시 토큰 검증 시 발생할 수 있는 오류에 대한 예외 처리가 강화되었습니다.

* **기타**
  * 토큰 재발급 성공 및 오류 메시지가 추가되었습니다.
  * 토큰 재발급 API가 인증 화이트리스트에 포함되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->