### PR TITLE
[FIX] 파라미터 위치 오류 해결

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/request/CostProposalRequestDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/request/CostProposalRequestDto.java
@@ -3,8 +3,11 @@ package org.appjam.bongbaek.domain.event.dto.request;
 import org.appjam.bongbaek.domain.event.dto.common.HighAccuracy;
 import org.appjam.bongbaek.domain.event.dto.common.LocationInfo;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import jakarta.validation.Valid;
 
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
 public record CostProposalRequestDto(
 		String category,
 		String relationship,

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
@@ -73,9 +73,18 @@ public class EventService {
 
         CostParamInfo costParams = CostParamInfo.of(member, costProposalRequestDto);
 
+        // LocationInfo가 null인 경우 반환값 임시
+        if(costProposalRequestDto.locationInfo() == null){
+            return CostProposalResponseDto.of(cost, range,
+                    costProposalRequestDto.category(),
+                    null,
+                    costParams);
+        }
+
         return CostProposalResponseDto.of(cost, range,
+                costProposalRequestDto.category(),
                 costProposalRequestDto.locationInfo().location(),
-                costProposalRequestDto.category(), costParams);
+                costParams);
     }
 
     public EventDetailResponseDto getEventByEventId(UUID eventId, UUID memberId) {


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #37 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 경조사 비용 추천API의 응답에서 파라미터가 뒤바뀐 오류를 해결합니다.
- 비용 추천의 요청 body에서 LocationInfo가 null인 경우의 예외처리 오류를 해결합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 경조사 비용 추천API의 응답에서 파라미터가 뒤바뀐 오류를 해결
- [x] LocationInfo가 null인 경우의 예외처리 오류를 해결

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
<img width="1482" height="739" alt="스크린샷 2025-07-15 오후 3 21 29" src="https://github.com/user-attachments/assets/50e4c6d7-033e-4b85-b630-1059dd3d5a62" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 나중에 nested record들이 null인 경우 내부 값 접근 과정에서의 `NullpointerException`을 잘 처리할 수 있는 방법을 더 찾아봐야할 것 같아요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 비용 제안 요청 시 위치 정보가 누락된 경우에도 오류 없이 정상적으로 처리되도록 개선되었습니다.

* **스타일**
  * JSON 직렬화 시 null 값 필드는 응답에서 제외되도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->