### PR TITLE
[FIX] hostName, hostNickname 숫자 허용

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/common/HostInfo.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/common/HostInfo.java
@@ -6,11 +6,11 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record HostInfo(
-		@Pattern(regexp = "^[가-힣a-zA-Z\\s]+$", message = "이름은 한글, 영어 대소문자, 공백으로만 입력 가능합니다")
-		@Size(min = 2, max = 10, message = "2자 이상 10자 이내만 기입할 수 있습니다")
+		@Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "특수문자는 기입할 수 없어요")
+		@Size(min = 2, max = 10, message = "2자 이상 10자 이내만 기입할 수 있어요")
 		String hostName,
-		@Pattern(regexp = "^[가-힣a-zA-Z\\s]+$", message = "별명은 한글, 영어 대소문자, 공백으로만 입력 가능합니다")
-		@Size(min = 2, max = 10, message = "2자 이상 10자 이내만 기입할 수 있습니다")
+		@Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "특수문자는 기입할 수 없어요")
+		@Size(min = 2, max = 10, message = "2자 이상 10자 이내만 기입할 수 있어요")
 		String hostNickname) {
 
 	public static HostInfo from(Event event) {


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #43 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 요구사항에 맞게 hostName과 hostNickname에 숫자를 허용
- 정규식에 0-9 를 추가하여 숫자 허용

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] host 이름과 별명 숫자 허용

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내용

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 요구사항 바로 머지 하겠습니다 🙇🙇‍♂️🙇‍♀️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 호스트 이름과 별명 입력 시 숫자 입력이 가능해졌으며, 안내 메시지가 더 친근하게 변경되었습니다.  
  * 특수문자는 입력할 수 없고, 글자 수는 2자 이상 10자 이하로 제한됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->