### PR TITLE
[HOTFIX] note가 null인  경우 표시되지 않는 문제 해결

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/common/EventInfo.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/common/EventInfo.java
@@ -11,11 +11,11 @@ public record EventInfo(
 		String relationship,
 		@Max(value = 99999999, message = "경조사비는 99,999,999원 이하여야 합니다")
 		int cost,
+		@JsonInclude(JsonInclude.Include.NON_NULL)
 		Boolean isAttend,
 		LocalDate eventDate,
 		@JsonInclude(JsonInclude.Include.NON_NULL)
 		Integer dDay,
-		@JsonInclude(JsonInclude.Include.NON_NULL)
 		String note
 ) {
 	public static EventInfo from(Event event) {


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- note가 null인 경우 표시되지 않는 문제를 해결합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] note가 null인 경우 표시되지 않는 문제를 해결

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 이거 나중에 dto를 분리하던가 아무튼 변경이 필요합니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 이벤트 정보에서 참석 여부(isAttend) 필드가 null일 경우 JSON에 표시되지 않도록 개선되었습니다.
  * 메모(note) 필드는 이제 값이 없더라도 항상 JSON에 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->