### PR TITLE
[REFAC] 엔티티 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     // jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.9.9'
 
     // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
@@ -1,8 +1,6 @@
 package org.appjam.bongbaek.domain.event.controller;
 
 import java.time.LocalDate;
-import java.util.UUID;
-
 import jakarta.validation.Valid;
 import org.appjam.bongbaek.domain.event.code.EventSuccessCode;
 import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
@@ -29,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -41,10 +38,11 @@ public class EventController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<EmptyBody>> createEvent(
-            @AuthenticationPrincipal final UUID memberId,
+            @AuthenticationPrincipal final String memberId,
             @RequestBody @Valid final EventWriteDto eventWriteDto
     ) {
         eventService.createEventInfo(memberId, eventWriteDto);
+
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(CommonSuccessCode.CREATED));
@@ -52,7 +50,7 @@ public class EventController {
 
     @GetMapping(path = "/history/{page}")
     public ResponseEntity<ApiResponse<EventListDto>> getEventHistory(
-            @AuthenticationPrincipal final UUID memberId,
+            @AuthenticationPrincipal final String memberId,
             @PathVariable(name = "page") final int page,
             @RequestParam(name = "category", required = false) final String category,
             @RequestParam(name = "attended", required = false) final Boolean attended
@@ -65,7 +63,7 @@ public class EventController {
 
     @GetMapping(path = "/upcoming/{page}")
     public ResponseEntity<ApiResponse<EventListDto>> getUpcomingEvents(
-            @AuthenticationPrincipal final UUID memberId,
+            @AuthenticationPrincipal final String memberId,
             @PathVariable(name = "page") final int page,
             @RequestParam(name = "category", required = false) final String category
     ) {
@@ -77,7 +75,7 @@ public class EventController {
 
     @PostMapping(path = "/cost")
     public ResponseEntity<ApiResponse<CostProposalResponseDto>> createEventCost(
-            @AuthenticationPrincipal final UUID memberId,
+            @AuthenticationPrincipal final String memberId,
             @RequestBody @Valid final CostProposalRequestDto costProposalRequestDto
     ){
         return ResponseEntity
@@ -88,8 +86,8 @@ public class EventController {
 
     @GetMapping(path = "/{eventId}")
     public ResponseEntity<ApiResponse<EventDetailResponseDto>> getEventByEventId(
-            @AuthenticationPrincipal final UUID memberId,
-            @PathVariable(name = "eventId") UUID eventId   // NOTE: 클라 요청 간에는 무조건 String
+            @AuthenticationPrincipal final String memberId,
+            @PathVariable(name = "eventId") String eventId   // NOTE: 클라 요청 간에는 무조건 String
     ){
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -98,7 +96,7 @@ public class EventController {
 
     @GetMapping(path = "/home")
     public ResponseEntity<ApiResponse<EventHomeResponseDto>> getEventsForHome(
-            @AuthenticationPrincipal final UUID memberId
+            @AuthenticationPrincipal final String memberId
     ){
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -107,8 +105,8 @@ public class EventController {
 
     @PutMapping(path = "/{eventId}")
     public ResponseEntity<ApiResponse<EmptyBody>> updateEvent(
-            @AuthenticationPrincipal final UUID memberId,
-            @PathVariable(name = "eventId") final UUID eventId,
+            @AuthenticationPrincipal final String memberId,
+            @PathVariable(name = "eventId") final String eventId,
             @RequestBody @Valid final EventUpdateRequestDto request
     ){
         eventService.updateEventByEventId(eventId, memberId, request);
@@ -120,8 +118,8 @@ public class EventController {
 
     @DeleteMapping(path = "/{eventId}")
     public ResponseEntity<ApiResponse<EmptyBody>> deleteEventByEventId(
-            @AuthenticationPrincipal final UUID memberId,
-            @PathVariable(name = "eventId") UUID eventId
+            @AuthenticationPrincipal final String memberId,
+            @PathVariable(name = "eventId") String eventId
     ) {
         eventService.deleteEventByEventId(eventId, memberId);
 
@@ -132,10 +130,9 @@ public class EventController {
 
     @DeleteMapping
     public ResponseEntity<ApiResponse<EmptyBody>> deleteEvents(
-            @AuthenticationPrincipal final UUID memberId,
+            @AuthenticationPrincipal final String memberId,
             @RequestBody EventDeleteRequestDto eventDeleteRequest
     ){
-
         eventService.deleteEvents(eventDeleteRequest, memberId);
 
         return ResponseEntity

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/request/EventDeleteRequestDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/request/EventDeleteRequestDto.java
@@ -1,9 +1,8 @@
 package org.appjam.bongbaek.domain.event.dto.request;
 
 import java.util.List;
-import java.util.UUID;
 
 public record EventDeleteRequestDto (
-        List<UUID> eventIds
+        List<String> eventIds
 ) {
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventDetailResponseDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventDetailResponseDto.java
@@ -3,10 +3,8 @@ package org.appjam.bongbaek.domain.event.dto.response;
 import org.appjam.bongbaek.domain.event.dto.common.*;
 import org.appjam.bongbaek.domain.event.entity.Event;
 
-import java.util.UUID;
-
 public record EventDetailResponseDto(
-        UUID eventId,
+        String eventId,
         HostInfo hostInfo,
         EventInfo eventInfo,
         LocationInfo locationInfo

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventHomeResponseDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventHomeResponseDto.java
@@ -8,7 +8,6 @@ import org.appjam.bongbaek.domain.event.entity.Event;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.UUID;
 
 public record EventHomeResponseDto (
         List<EventResponseDto> events
@@ -22,7 +21,7 @@ public record EventHomeResponseDto (
                      );
     }
 
-    private record EventResponseDto (UUID eventId, HostInfo hostInfo, EventInfo eventInfo, LocationInfo locationInfo) {
+    private record EventResponseDto (String eventId, HostInfo hostInfo, EventInfo eventInfo, LocationInfo locationInfo) {
 
         private static EventResponseDto from(Event event) {
             return new  EventResponseDto(event.getEventId(),
@@ -38,5 +37,3 @@ public record EventHomeResponseDto (
         }
     }
 }
-
-

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventListDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/response/EventListDto.java
@@ -1,8 +1,6 @@
 package org.appjam.bongbaek.domain.event.dto.response;
 
 import java.util.List;
-import java.util.UUID;
-
 import org.appjam.bongbaek.domain.event.entity.Event;
 import org.appjam.bongbaek.domain.event.dto.common.EventInfo;
 import org.appjam.bongbaek.domain.event.dto.common.HostInfo;
@@ -21,7 +19,7 @@ public record EventListDto(
 		return new EventListDto(elements, events.getNumber(), events.isLast());
 	}
 
-	private record EventListElement(UUID eventId, HostInfo hostInfo, EventInfo eventInfo) {
+	private record EventListElement(String eventId, HostInfo hostInfo, EventInfo eventInfo) {
 		private static EventListElement from(Event event) {
 			return new EventListElement(event.getEventId(), HostInfo.from(event),
 					EventInfo.from(

--- a/src/main/java/org/appjam/bongbaek/domain/event/entity/Event.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/entity/Event.java
@@ -1,7 +1,9 @@
 package org.appjam.bongbaek.domain.event.entity;
 
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.ForeignKey;
 import java.time.LocalDate;
-import java.util.UUID;
 
 import org.appjam.bongbaek.domain.common.BaseEntity;
 import org.appjam.bongbaek.domain.event.dto.request.EventUpdateRequestDto;
@@ -22,6 +24,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 
 @Entity
 @Getter
@@ -31,11 +34,13 @@ import lombok.NoArgsConstructor;
 				@Index(name = "idx_member_id", columnList = "member_id")
 		}
 )
+@Comment("경조사 정보")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event extends BaseEntity {
 	@Id
-	@Column(name = "event_id", columnDefinition = "BINARY(16)")
-	private UUID eventId;
+    @Tsid
+	@Column(name = "event_id", length = 13)
+	private String eventId;
 
 	// host
 	@Column(name = "host_name", length = 30, nullable = false)
@@ -85,7 +90,7 @@ public class Event extends BaseEntity {
 	private double longitude;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
+	@JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
 	private Member member;
 
 	@Builder
@@ -93,7 +98,6 @@ public class Event extends BaseEntity {
 			int meetFrequency,
 			Category eventCategory, LocalDate eventDate, boolean attended, String note, int cost,
 			String location, String address, double latitude, double longitude, Member member) {
-		this.eventId = UUID.randomUUID();
 		this.hostName = hostName;
 		this.hostNickname = hostNickname;
 		this.relationship = relationship;

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventRepository.java
@@ -3,18 +3,16 @@ package org.appjam.bongbaek.domain.event.repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
-
 import org.appjam.bongbaek.domain.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface EventRepository extends JpaRepository<Event, UUID>, EventSearchRepository{
+public interface EventRepository extends JpaRepository<Event, String>, EventSearchRepository{
 
-    List<Event> findTop3ByEventDateGreaterThanEqualAndMemberMemberIdOrderByEventDateAsc(LocalDate now, UUID member_memberId); // TO DO: jwt 발급 시 사용
+    List<Event> findTop3ByEventDateGreaterThanEqualAndMemberMemberIdOrderByEventDateAsc(LocalDate now, String member_memberId); // TO DO: jwt 발급 시 사용
 
-    Optional<Event> findEventByEventIdAndMemberMemberId(UUID eventId, UUID memberMemberId);
+    Optional<Event> findEventByEventIdAndMemberMemberId(String eventId, String memberMemberId);
 
-    List<Event> findAllByEventIdInAndMemberMemberId(List<UUID> eventIds, UUID memberId);
+    List<Event> findAllByEventIdInAndMemberMemberId(List<String> eventIds, String memberId);
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
@@ -1,14 +1,12 @@
 package org.appjam.bongbaek.domain.event.repository;
 
-import java.util.UUID;
-
 import org.appjam.bongbaek.domain.event.entity.Category;
 import org.appjam.bongbaek.domain.event.entity.Event;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface EventSearchRepository {
-	Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(UUID memberId, Category category, Boolean attended, Pageable pageable);
+	Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(String memberId, Category category, Boolean attended, Pageable pageable);
 
-	Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(UUID memberId, Category category, Pageable pageable);
+	Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(String memberId, Category category, Pageable pageable);
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -2,8 +2,6 @@ package org.appjam.bongbaek.domain.event.repository;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
-
 import org.appjam.bongbaek.domain.event.entity.Category;
 import org.appjam.bongbaek.domain.event.entity.Event;
 import org.appjam.bongbaek.domain.event.entity.QEvent;
@@ -11,10 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
-
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -24,7 +20,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 
 	@Override
 	public Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(
-			UUID memberId,
+            String memberId,
 			Category category,
 			Boolean attended,
 			Pageable pageable
@@ -53,8 +49,11 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 	}
 
 	@Override
-	public Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(UUID memberId, Category category,
-			Pageable pageable) {
+	public Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(
+        String memberId,
+        Category category,
+        Pageable pageable
+    ) {
 		QEvent qEvent = QEvent.event;
 		int pageSize = pageable.getPageSize();
 

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
@@ -2,7 +2,6 @@ package org.appjam.bongbaek.domain.event.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.UUID;
 
 import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventDeleteRequestDto;
@@ -27,44 +26,64 @@ import org.appjam.bongbaek.domain.event.dto.response.EventHomeResponseDto;
 import org.appjam.bongbaek.domain.event.entity.Event;
 import org.appjam.bongbaek.domain.event.repository.EventRepository;
 import org.springframework.stereotype.Service;
-
 import lombok.RequiredArgsConstructor;
-
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class EventService {
+
     private static final int PAGE_SIZE = 10;
 
     private final EventRepository eventRepository;
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void createEventInfo(final UUID memberId, final EventWriteDto eventWriteDto) {
+    public void createEventInfo(
+        final String memberId,
+        final EventWriteDto eventWriteDto
+    ) {
         Member memberProxy = memberRepository.getReferenceById(memberId);
         Event event = eventWriteDto.toEntity(memberProxy);
         eventRepository.save(event);
     }
 
-    public EventListDto getEventHistory(final UUID memberId, final int page, final String category,
-            final Boolean attended) {
+    public EventListDto getEventHistory(
+        final String memberId,
+        final int page,
+        final String category,
+        final Boolean attended
+    ) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        Slice<Event> result = eventRepository.findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(memberId,
-                Category.of(category), attended, pageable);
+        Slice<Event> result = eventRepository.findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(
+            memberId,
+            Category.of(category),
+            attended,
+            pageable
+        );
 
         return EventListDto.of(result);
     }
 
-    public EventListDto getUpcomingEvents(final UUID memberId, final int page, final String category) {
+    public EventListDto getUpcomingEvents(
+        final String memberId,
+        final int page,
+        final String category
+    ) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        Slice<Event> result = eventRepository.findUpcomingEventsByMemberIdAndCategoryOrderBy(memberId,
-                Category.of(category), pageable);
+        Slice<Event> result = eventRepository.findUpcomingEventsByMemberIdAndCategoryOrderBy(
+            memberId,
+            Category.of(category),
+            pageable
+        );
 
         return EventListDto.of(result);
     }
 
-    public CostProposalResponseDto getCostProposal(UUID memberId, CostProposalRequestDto costProposalRequestDto) {
+    public CostProposalResponseDto getCostProposal(
+        String memberId,
+        CostProposalRequestDto costProposalRequestDto
+    ) {
         Member member = memberRepository.findById(memberId).orElseThrow(IllegalArgumentException::new);
 
         int cost = CostCalculator.calculateCost(member, costProposalRequestDto);
@@ -74,57 +93,74 @@ public class EventService {
         CostParamInfo costParams = CostParamInfo.of(member, costProposalRequestDto);
 
         // LocationInfo가 null인 경우 반환값 임시
-        if(costProposalRequestDto.locationInfo() == null){
-            return CostProposalResponseDto.of(cost, range,
-                    costProposalRequestDto.category(),
-                    null,
-                    costParams);
+        if (costProposalRequestDto.locationInfo() == null) {
+            return CostProposalResponseDto.of(
+                cost,
+                range,
+                costProposalRequestDto.category(),
+                null,
+                costParams
+            );
         }
 
-        return CostProposalResponseDto.of(cost, range,
-                costProposalRequestDto.category(),
-                costProposalRequestDto.locationInfo().location(),
-                costParams);
+        return CostProposalResponseDto.of(
+            cost,
+            range,
+            costProposalRequestDto.category(),
+            costProposalRequestDto.locationInfo().location(),
+            costParams
+        );
     }
 
-    public EventDetailResponseDto getEventByEventId(UUID eventId, UUID memberId) {
-
+    public EventDetailResponseDto getEventByEventId(
+        String eventId,
+        String memberId
+    ) {
         Event event = eventRepository.findEventByEventIdAndMemberMemberId(eventId, memberId)
-                .orElseThrow(NotFoundEventException::new);
+            .orElseThrow(NotFoundEventException::new);
 
         return EventDetailResponseDto.of(event);
     }
 
 
-    public EventHomeResponseDto getEventsForHome(LocalDate now, UUID memberId){
-
+    public EventHomeResponseDto getEventsForHome(
+        LocalDate now,
+        String memberId
+    ) {
         List<Event> events = eventRepository.findTop3ByEventDateGreaterThanEqualAndMemberMemberIdOrderByEventDateAsc(now, memberId);
 
         return EventHomeResponseDto.from(events);
     }
 
     @Transactional
-    public void updateEventByEventId(UUID eventId, UUID memberId, EventUpdateRequestDto request) {
-
+    public void updateEventByEventId(
+        String eventId,
+        String memberId,
+        EventUpdateRequestDto request
+    ) {
         Event event = eventRepository.findEventByEventIdAndMemberMemberId(eventId, memberId)
-                .orElseThrow(NotFoundEventException::new);
+            .orElseThrow(NotFoundEventException::new);
 
         event.updateFromDto(request);
     }
 
     @Transactional
-    public void deleteEventByEventId(UUID eventId, UUID memberId) {
-
+    public void deleteEventByEventId(
+        String eventId,
+        String memberId
+    ) {
         Event event = eventRepository.findEventByEventIdAndMemberMemberId(eventId, memberId)
-                .orElseThrow(NotFoundEventException::new);
+            .orElseThrow(NotFoundEventException::new);
 
         eventRepository.delete(event);
     }
 
     @Transactional
-    public void deleteEvents(EventDeleteRequestDto eventDeleteRequest, UUID memberUUID) {
-
-        List<Event> events = eventRepository.findAllByEventIdInAndMemberMemberId(eventDeleteRequest.eventIds(), memberUUID);
+    public void deleteEvents(
+        EventDeleteRequestDto eventDeleteRequest,
+        String memberId
+    ) {
+        List<Event> events = eventRepository.findAllByEventIdInAndMemberMemberId(eventDeleteRequest.eventIds(), memberId);
 
         if (events.size() != eventDeleteRequest.eventIds().size()) {
             throw new NotFoundEventException();

--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -54,7 +54,7 @@ public class MemberController {
     @PostMapping("/member/reissue")
     public ResponseEntity<ApiResponse<TokenResponse>> reissueTokens(
             @RequestBody final ReissueRequest reissueRequest
-            ) {
+    ) {
         TokenResponse tokenResponse = memberService.reissueTokens(reissueRequest.refreshToken());
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
@@ -1,9 +1,8 @@
 package org.appjam.bongbaek.domain.member.entity;
 
+import io.hypersistence.utils.hibernate.id.Tsid;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.UUID;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,15 +13,18 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 
 @Entity
 @Getter
 @Table(name = "member")
+@Comment("회원 정보")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 	@Id
-	@Column(name = "member_id", columnDefinition = "BINARY(16)")
-	private UUID memberId;
+    @Tsid
+	@Column(name = "member_id", length = 13)
+	private String memberId;
 
 	@Column(name = "member_name", length = 30, nullable = false)
 	private String memberName;
@@ -42,7 +44,6 @@ public class Member {
 
 	@Builder
 	private Member(String memberName, LocalDate memberBirthday, IncomeType memberIncome, String appleId, Long kakaoId) {
-		this.memberId = UUID.randomUUID();
 		this.memberName = memberName;
 		this.memberBirthday = memberBirthday;
 		this.memberIncome = memberIncome;

--- a/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberRepository.java
@@ -3,10 +3,9 @@ package org.appjam.bongbaek.domain.member.repository;
 import org.appjam.bongbaek.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import java.util.UUID;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, UUID> {
+public interface MemberRepository extends JpaRepository<Member, String> {
 
     boolean existsByKakaoId(final Long kakaoId);
     Member findByKakaoId(final Long kakaoId);

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -17,8 +17,6 @@ import org.appjam.bongbaek.global.oauth.kakao.KakaoLoginClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -71,6 +69,7 @@ public class MemberService {
     private TokenResponse generateTokensForMember(Member member) {
         final String accessToken = jwtProvider.generateAccessToken(member.getMemberId());
         final String refreshToken = jwtProvider.generateRefreshToken(member.getMemberId());
+
         return TokenResponse.of(accessToken, refreshToken);
     }
 
@@ -78,7 +77,7 @@ public class MemberService {
     public TokenResponse reissueTokens(final String refreshToken) {
         jwtValidator.validateRefreshToken(refreshToken);
 
-        UUID memberId = jwtParser.getUserFromJwt(refreshToken);
+        String memberId = jwtParser.getUserFromJwt(refreshToken);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
 

--- a/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtAuthenticationFilter.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtAuthenticationFilter.java
@@ -13,9 +13,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetailsS
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-
 import java.io.IOException;
-import java.util.UUID;
 
 import static org.appjam.bongbaek.global.jwt.enums.JwtValidationType.VALID_JWT;
 
@@ -30,12 +28,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
-
         try {
             final String token = getJwtFromRequest(request);
 
             if (token != null && jwtValidator.validateToken(token) == VALID_JWT) {
-                UUID memberId = jwtParser.getUserFromJwt(token);
+                String memberId = jwtParser.getUserFromJwt(token);
                 MemberAuthentication authentication = MemberAuthentication.createMemberAuthentication(memberId);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication); // NOTE: 메타데이터, 스레드에 인증 저장
@@ -56,5 +53,3 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null;
     }
 }
-
-

--- a/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtParser.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtParser.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.util.UUID;
 
 @Component
 public class JwtParser {
@@ -25,9 +24,10 @@ public class JwtParser {
                 .getBody();
     }
 
-    public UUID getUserFromJwt(String token) {
+    public String getUserFromJwt(String token) {
         Claims claims = getBody(token);
-        return UUID.fromString(claims.get(MEMBER_ID).toString());
+
+        return claims.get(MEMBER_ID).toString();
     }
 
     public SecretKey getSigningKey() {

--- a/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtProvider.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/util/JwtProvider.java
@@ -3,9 +3,7 @@ package org.appjam.bongbaek.global.jwt.util;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
 import java.util.Date;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -19,22 +17,22 @@ public class JwtProvider {
 
     private final JwtParser jwtParser;
 
-    private String generateToken(UUID memberId, Long expirationTime) {
+    private String generateToken(String memberId, Long expirationTime) {
         final Date now = new Date();
 
         return Jwts.builder()
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + expirationTime))
-                .claim(MEMBER_ID, memberId.toString())
+                .claim(MEMBER_ID, memberId)
                 .signWith(jwtParser.getSigningKey())
                 .compact();
     }
 
-    public String generateAccessToken(UUID memberId) {
+    public String generateAccessToken(String memberId) {
         return generateToken(memberId, ACCESS_TOKEN_EXPIRATION_TIME);
     } // NOTE: header.payload.signature 형태 생성
 
-    public String generateRefreshToken(UUID memberId) {
+    public String generateRefreshToken(String memberId) {
         return generateToken(memberId, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 }

--- a/src/main/java/org/appjam/bongbaek/global/jwt/util/MemberAuthentication.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/util/MemberAuthentication.java
@@ -5,14 +5,13 @@ import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.UUID;
 
 public class MemberAuthentication extends UsernamePasswordAuthenticationToken {
     public MemberAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
         super(principal, credentials, authorities);
     }
 
-    public static MemberAuthentication createMemberAuthentication(UUID memberId) {
+    public static MemberAuthentication createMemberAuthentication(String memberId) {
         return new MemberAuthentication(memberId, null, Collections.emptyList());  // TODO: 권한 레벨 현재 X. 필요시 추가 가능
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #53 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 엔티티를 리팩토링합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 엔티티의 id를 uuid->tsid로 변경합니다.
- [x] 외래키를 no_constraint로 설정합니다.

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내용

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 이벤트·회원 ID를 TSID 기반 13자리 문자열로 전환하여 더 짧고 일관된 식별자를 제공합니다.
  - 모든 이벤트/회원 관련 API에서 ID를 문자열로 사용하도록 통일했습니다. 요청/응답 및 URL 경로의 ID 표현이 문자열로 변경됩니다.
  - 기능 동작은 동일하며 성능과 유지보수성을 개선했습니다.
- Chores
  - JPA 유틸리티 라이브러리를 추가해 ID 처리 및 ORM 호환성을 강화했습니다.
  - 인증 성공 로그를 보강해 운영 모니터링을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->