### PR TITLE
[FEAT] 회원정보 수정 기능 구현

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -50,6 +50,18 @@ public class MemberController {
                 .body(ApiResponse.success(CommonSuccessCode.SIGNUP_COMPLETED, loginResponse));
     }
 
+    @Operation(summary = "로그아웃", description = "현재 사용자의 모든 리프레시 토큰을 무효화합니다.")
+    @PostMapping("/member/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+        @RequestHeader("Authorization") String authorization
+    ) {
+        memberService.logout(authorization);
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(ApiResponse.success(CommonSuccessCode.OK, null));
+    }
+
+
     @Operation(summary = "토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다.")
     @PostMapping("/member/reissue")
     public ResponseEntity<ApiResponse<TokenResponse>> reissueTokens(

--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -2,17 +2,21 @@ package org.appjam.bongbaek.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.appjam.bongbaek.domain.member.dto.LoginRequest;
 import org.appjam.bongbaek.domain.member.dto.LoginResponse;
 import org.appjam.bongbaek.domain.member.dto.ReissueRequest;
 import org.appjam.bongbaek.domain.member.dto.SignUpRequest;
+import org.appjam.bongbaek.domain.member.dto.UpdateMemberRequest;
 import org.appjam.bongbaek.domain.member.service.MemberService;
 import org.appjam.bongbaek.global.api.ApiResponse;
+import org.appjam.bongbaek.global.api.ApiResponse.EmptyBody;
 import org.appjam.bongbaek.global.common.CommonSuccessCode;
 import org.appjam.bongbaek.global.jwt.dto.TokenResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원", description = "회원 관련 API")
@@ -71,5 +75,18 @@ public class MemberController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(CommonSuccessCode.TOKEN_REISSUED, tokenResponse));
+    }
+
+    @Operation(summary = "회원 프로필 수정", description = "이름/생일/소득을 전달하여 프로필을 전체 교체합니다.")
+    @PutMapping(path = "/member/profile")
+    public ResponseEntity<ApiResponse<EmptyBody>> updateProfile(
+        @AuthenticationPrincipal final String memberId,
+        @RequestBody @Valid final UpdateMemberRequest request
+    ) {
+        memberService.updateProfile(memberId, request);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.success(CommonSuccessCode.OK));
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -87,6 +87,6 @@ public class MemberController {
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(ApiResponse.success(CommonSuccessCode.OK));
+            .body(ApiResponse.success(CommonSuccessCode.OK, null));
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/UpdateMemberRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/UpdateMemberRequest.java
@@ -1,16 +1,26 @@
 package org.appjam.bongbaek.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
-import org.appjam.bongbaek.domain.member.entity.IncomeType;
-import org.appjam.bongbaek.domain.member.entity.Member;
 
 public record UpdateMemberRequest(
-        @Schema(description = "회원 이름", example = "김민경")
-        String memberName,
-        @Schema(description = "회원 생일", example = "2001-02-18")
-        LocalDate memberBirthday,
-        @Schema(description = "회원 소득", example = "200만원 이상")
-        String memberIncome
-) {
-}
+    @NotBlank(message = "이름은 필수입니다.")
+    @Pattern(regexp = "^[가-힣a-zA-Z0-9\\s]+$", message = "특수문자는 기입할 수 없어요")
+    @Size(max = 30, message = "이름은 최대 30자까지 입력 가능합니다.")
+    @Schema(description = "회원 이름", example = "김민경")
+    String memberName,
+
+    @NotNull(message = "생일은 필수입니다.")
+    @Past(message = "생일은 오늘보다 과거 날짜여야 합니다.")
+    @Schema(description = "회원 생일", example = "2001-02-18")
+    LocalDate memberBirthday,
+
+    @NotBlank(message = "소득은 필수입니다.")
+    @Schema(description = "회원 소득", example = "200만원 이상")
+    String memberIncome
+) {}

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/UpdateMemberRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/UpdateMemberRequest.java
@@ -1,0 +1,16 @@
+package org.appjam.bongbaek.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import org.appjam.bongbaek.domain.member.entity.IncomeType;
+import org.appjam.bongbaek.domain.member.entity.Member;
+
+public record UpdateMemberRequest(
+        @Schema(description = "회원 이름", example = "김민경")
+        String memberName,
+        @Schema(description = "회원 생일", example = "2001-02-18")
+        LocalDate memberBirthday,
+        @Schema(description = "회원 소득", example = "200만원 이상")
+        String memberIncome
+) {
+}

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
@@ -13,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.appjam.bongbaek.domain.member.dto.UpdateMemberRequest;
 import org.hibernate.annotations.Comment;
 
 @Entity
@@ -50,6 +51,12 @@ public class Member {
 		this.appleId = appleId;
 		this.kakaoId = kakaoId;
 	}
+
+    public void update(UpdateMemberRequest request){
+        this.memberName=request.memberName().trim();
+        this.memberBirthday=request.memberBirthday();
+        this.memberIncome=IncomeType.of(request.memberIncome());
+    }
 
 	public int getAge(){
 		return Period.between(this.memberBirthday, LocalDate.now()).getYears();

--- a/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberRepository.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
-
     boolean existsByKakaoId(final Long kakaoId);
     Optional<Member> findByKakaoId(final Long kakaoId);
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -11,6 +11,8 @@ import org.appjam.bongbaek.domain.member.repository.MemberRepository;
 import org.appjam.bongbaek.global.common.CommonErrorCode;
 import org.appjam.bongbaek.global.exception.CustomException;
 import org.appjam.bongbaek.global.exception.SignUpRequiredException;
+import org.appjam.bongbaek.global.jwt.JwtBlacklistManager;
+import org.appjam.bongbaek.global.jwt.JwtRefreshStore;
 import org.appjam.bongbaek.global.jwt.dto.TokenResponse;
 import org.appjam.bongbaek.global.jwt.components.JwtParser;
 import org.appjam.bongbaek.global.jwt.components.JwtProvider;
@@ -32,6 +34,8 @@ public class MemberService {
     private final JwtProvider jwtProvider;
     private final JwtValidator jwtValidator;
     private final JwtParser jwtParser;
+    private final JwtRefreshStore jwtRefreshStore;
+    private final JwtBlacklistManager jwtBlacklistManager;
 
     @Transactional
     public LoginResponse login(
@@ -74,32 +78,58 @@ public class MemberService {
         }
     }
 
-    private TokenResponse generateTokensForMember(
-        Member member
-    ) {
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-            member.getMemberId(),
-            "", // credentials 미사용
-            Collections.emptyList() // role 미사용
-        );
+    @Transactional
+    public void logout(final String authorization) {
+        if (authorization == null || !authorization.startsWith("Bearer ")) return;
 
-        return jwtProvider.generateToken(authentication);
+        String accessToken = authorization.substring("Bearer ".length());
+        jwtValidator.validateToken(accessToken);
+
+        String memberId = jwtParser.parseClaims(accessToken).getSubject();
+
+        // 유저의 모든 refreshToken 제거
+        jwtRefreshStore.deleteAllForUser(memberId);
+
+        // 현재 accessToken 차단
+        jwtBlacklistManager.add(authorization);
     }
 
     @Transactional
-    public TokenResponse reissueTokens(
-        final String refreshToken
-    ) {
-        // refresh token 유효성 검사
+    public TokenResponse reissueTokens(final String refreshToken) {
         jwtValidator.validateToken(refreshToken);
 
-        // refresh 토큰에서 sub(=memberId) 파싱
+        // 저장된 refreshToken인지 확인
+        if (!jwtRefreshStore.exists(refreshToken)) {
+            throw new CustomException(CommonErrorCode.UNAUTHORIZED);
+        }
+
         String memberId = jwtParser.parseClaims(refreshToken).getSubject();
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
 
-        // 토큰 재발급
+        // 사용한 refreshToken 폐기
+        jwtRefreshStore.deleteToken(refreshToken);
+
+        // 새로운 access+refresh 토큰 발급
         return generateTokensForMember(member);
+    }
+
+    /**
+     * 새 access+refresh 토큰 발급
+     * + refreshtoken Redis 저장
+     * */
+    private TokenResponse generateTokensForMember(Member member) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+            member.getMemberId(), "", Collections.emptyList()
+        );
+        TokenResponse tokenResponse = jwtProvider.generateToken(auth);
+
+        long refreshTtlSec = Math.max(1, (tokenResponse.refreshToken().expiredAt() - System.currentTimeMillis()) / 1000);
+
+        // refresh token redis에 저장
+        jwtRefreshStore.save(member.getMemberId(), tokenResponse.refreshToken().token(), refreshTtlSec);
+
+        return tokenResponse;
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.appjam.bongbaek.domain.member.dto.LoginResponse;
 import org.appjam.bongbaek.domain.member.dto.SignUpRequest;
+import org.appjam.bongbaek.domain.member.dto.UpdateMemberRequest;
 import org.appjam.bongbaek.domain.member.entity.IncomeType;
 import org.appjam.bongbaek.domain.member.entity.Member;
 import org.appjam.bongbaek.domain.member.repository.MemberRepository;
@@ -131,5 +132,13 @@ public class MemberService {
         jwtRefreshStore.save(member.getMemberId(), tokenResponse.refreshToken().token(), refreshTtlSec);
 
         return tokenResponse;
+    }
+
+    @Transactional
+    public void updateProfile(final String memberId, final UpdateMemberRequest request) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
+
+        member.update(request);
     }
 }

--- a/src/main/java/org/appjam/bongbaek/global/config/RedisConfig.java
+++ b/src/main/java/org/appjam/bongbaek/global/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package org.appjam.bongbaek.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
+        return new StringRedisTemplate(cf);
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/jwt/JwtBlacklistManager.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/JwtBlacklistManager.java
@@ -1,0 +1,63 @@
+package org.appjam.bongbaek.global.jwt;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.appjam.bongbaek.global.jwt.components.JwtParser;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtBlacklistManager {
+
+    private static final String PREFIX = "blackList:";
+
+    private final StringRedisTemplate redis;
+    private final JwtParser jwtParser;
+
+    /**
+     * 토큰을 블랙리스트에 추가
+     * (TTL = 토큰만료까지)
+     * */
+    public void add(String token) {
+        String tokenNoBearer = normalize(token);
+
+        // 초단위로 ttl 계산, 최소 1초
+        long ttlSec = Math.max(1, (jwtParser.getExpire(tokenNoBearer).getTime() - System.currentTimeMillis()) / 1000);
+
+        // redis에 "blackList:토큰값" 키 생성
+        redis.opsForValue().set(key(tokenNoBearer), "1", ttlSec, TimeUnit.SECONDS);
+    }
+
+    /**
+     * 블랙리스트에 토큰이 있는지 확인
+     * */
+    public boolean contains(String authorizationBearer) {
+        String token = normalize(authorizationBearer);
+        return redis.hasKey(key(token));
+    }
+
+    /*
+     * redis key 생성 메서드
+     */
+    private String key(String token) {
+        return PREFIX + token;
+    }
+
+    /*
+     * "Bearer "로 시작하는지 확인 메서드
+     */
+    private boolean isBearer(String token) {
+        return token != null && token.startsWith("Bearer ");
+    }
+
+    /*
+     * "Bearer " 제거 메서드
+     */
+    private String normalize(String token) {
+        if (token == null) return "";
+
+        return isBearer(token) ? token.substring(7) : token;
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/jwt/JwtRefreshStore.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/JwtRefreshStore.java
@@ -1,0 +1,60 @@
+package org.appjam.bongbaek.global.jwt;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRefreshStore {
+
+    private final StringRedisTemplate redis;
+
+    // redis set 키
+    private String memberKey(String memberId)   { return "rt:member:"  + memberId; }
+
+    // redis 단건 키
+    private String tokenKey(String refresh)   { return "rt:token:" + refresh; }
+
+    /**
+     * redis 세트에 추가/설정
+     * */
+    public void save(String memberId, String refreshToken, long ttlSeconds) {
+        redis.opsForSet().add(memberKey(memberId), refreshToken);
+        redis.opsForValue().set(tokenKey(refreshToken), memberId, Math.max(ttlSeconds, 1), TimeUnit.SECONDS);
+    }
+
+    /**
+     * 해당 키가 존재하는지 확인
+     * */
+    public boolean exists(String refreshToken) {
+        Boolean has = redis.hasKey(tokenKey(refreshToken));
+        return Boolean.TRUE.equals(has);
+    }
+
+    /**
+     * 재발급 후, 이전 refresh 토큰 단일 폐기
+     * */
+    public void deleteToken(String refreshToken) {
+        String tk = tokenKey(refreshToken);
+        String memberId = redis.opsForValue().get(tk);
+        if (memberId != null) {
+            redis.opsForSet().remove(memberKey(memberId), refreshToken);
+        }
+        redis.delete(tk);
+    }
+
+    /**
+     * 모든 refresh token 폐기(로그아웃/강제 로그아웃)
+     * */
+    public void deleteAllForUser(String memberId) {
+        String uk = memberKey(memberId);
+        Set<String> tokens = redis.opsForSet().members(uk);
+        if (tokens != null) {
+            for (String t : tokens) redis.delete(tokenKey(t));
+        }
+        redis.delete(uk);
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/global/jwt/components/JwtParser.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/components/JwtParser.java
@@ -3,6 +3,7 @@ package org.appjam.bongbaek.global.jwt.components;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.appjam.bongbaek.global.common.CommonErrorCode;
 import org.appjam.bongbaek.global.exception.CustomException;
@@ -43,5 +44,14 @@ public class JwtParser {
         Claims claims = parseClaims(token);
 
         return claims.getSubject();
+    }
+
+    public Date getExpire(final String token) {
+        return Jwts.parser()
+            .verifyWith(secretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getExpiration();
     }
 }

--- a/src/main/java/org/appjam/bongbaek/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/filter/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.appjam.bongbaek.global.jwt.JwtBlacklistManager;
 import org.appjam.bongbaek.global.jwt.components.JwtParser;
 import org.appjam.bongbaek.global.jwt.components.JwtValidator;
 import org.appjam.bongbaek.global.jwt.data.MemberAuthentication;
@@ -22,6 +23,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtValidator jwtValidator;
     private final JwtParser jwtParser;
+    private final JwtBlacklistManager jwtBlacklistManager;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,
@@ -30,10 +32,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String token = resolveToken(request);
 
         try {
-            if (token != null && !token.isBlank() && jwtValidator.validateToken(token)) {
-                String memberId = jwtParser.getMemberIdFromAccessToken(token);
-                MemberAuthentication authentication = MemberAuthentication.createMemberAuthentication(memberId);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (token != null && !token.isBlank()) {
+                // 블랙리스트, 로그아웃된 토큰인지 확인
+                if (jwtBlacklistManager.contains("Bearer " + token)) {
+                    SecurityContextHolder.clearContext();
+                } else if (jwtValidator.validateToken(token)) {
+                    String memberId = jwtParser.getMemberIdFromAccessToken(token);
+                    MemberAuthentication authentication = MemberAuthentication.createMemberAuthentication(memberId);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
         } catch (Exception e) {
             SecurityContextHolder.clearContext();


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #61 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 회원 프로필 수정 기능을 구현합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 회원 프로필 수정 요청 dto 작성
- [x] 회원 프로필 update 메서드 작성
- [x] 회원 프로필 수정 api 작성

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
<img width="457" height="338" alt="image" src="https://github.com/user-attachments/assets/74316ee1-b295-48d6-a5b9-87feee6247a8" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 로그아웃 API 추가: 로그아웃 시 사용자에 대한 모든 리프레시 토큰이 무효화되고 현재 액세스 토큰이 차단됩니다.
  - 프로필 수정 API 추가: 이름·생년월일·소득을 검증해 회원 정보를 업데이트합니다.
  - 리프레시 토큰 재발급 강화: 서버에 등록된 토큰만 재발급 가능하며 사용된 토큰은 폐기됩니다.
- **작업**
  - Redis 연동 및 토큰 블랙리스트/저장소 추가로 인증 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->