### PR TITLE
[FEAT] 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.appjam.bongbaek.domain.member.dto.LoginResponse;
 import org.appjam.bongbaek.domain.member.dto.ReissueRequest;
 import org.appjam.bongbaek.domain.member.dto.SignUpRequest;
 import org.appjam.bongbaek.domain.member.dto.UpdateMemberRequest;
+import org.appjam.bongbaek.domain.member.dto.WithdrawRequest;
 import org.appjam.bongbaek.domain.member.service.MemberService;
 import org.appjam.bongbaek.global.api.ApiResponse;
 import org.appjam.bongbaek.global.api.ApiResponse.EmptyBody;
@@ -84,6 +85,20 @@ public class MemberController {
         @RequestBody @Valid final UpdateMemberRequest request
     ) {
         memberService.updateProfile(memberId, request);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.success(CommonSuccessCode.OK, null));
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "탈퇴 사유(INCONVENIENT/PRIVACY_CONCERN/RARELY_USED/BUG_OR_ERROR/NEW_ACCOUNT) 또는 탈퇴 상세 사유(50자 이내)로 탈퇴합니다.")
+    @PostMapping("/member/withdraw")
+    public ResponseEntity<ApiResponse<EmptyBody>> withdraw(
+        @RequestHeader(value = "Authorization") final String accessToken,
+        @AuthenticationPrincipal final String memberId,
+        @Valid @RequestBody final WithdrawRequest request
+    ) {
+        memberService.withdraw(accessToken, memberId, request);
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -91,7 +91,15 @@ public class MemberController {
             .body(ApiResponse.success(CommonSuccessCode.OK, null));
     }
 
-    @Operation(summary = "회원 탈퇴", description = "탈퇴 사유(INCONVENIENT/PRIVACY_CONCERN/RARELY_USED/BUG_OR_ERROR/NEW_ACCOUNT) 또는 탈퇴 상세 사유(50자 이내)로 탈퇴합니다.")
+    @Operation(
+        summary = "회원 탈퇴",
+        description = """
+        사전 정의 사유(INCONVENIENT/PRIVACY_CONCERN/RARELY_USED/BUG_OR_ERROR/NEW_ACCOUNT/OTHER)로 탈퇴합니다.
+        - reason: 필수
+        - reason=OTHER일 때 detail: 1~50자 필수
+        - 그 외 사유일 때 detail: null 필수
+        """
+    )
     @PostMapping("/member/withdraw")
     public ResponseEntity<ApiResponse<EmptyBody>> withdraw(
         @RequestHeader(value = "Authorization") final String accessToken,

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
@@ -15,6 +15,7 @@ public record WithdrawRequest (
 ) {
     // 검증 단계
     @AssertTrue(message = "사전 정의 사유를 선택하거나 상세 사유를 1~50자 입력해야 합니다.")
+    @Schema(hidden = true)
     public boolean isValid() {
         if (withdrawalReason == null) {
             return detail != null && !detail.isBlank() && detail.trim().length() <= 50;

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
@@ -1,0 +1,24 @@
+package org.appjam.bongbaek.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Size;
+import org.appjam.bongbaek.domain.member.enums.WithdrawalReason;
+
+public record WithdrawRequest (
+    @Schema(description = "탈퇴 사유 (없으면 null)", example = "INCONVENIENT")
+    WithdrawalReason withdrawalReason,
+
+    @Schema(description = "자유 입력 사유 (reason이 null일 때 필수, 영문/한글/특수문자/공백 포함 최대 50자)")
+    @Size(max = 50, message = "상세 사유는 50자 이내로 입력해주세요.")
+    String detail
+) {
+    // 검증 단계
+    @AssertTrue(message = "사전 정의 사유를 선택하거나 상세 사유를 1~50자 입력해야 합니다.")
+    public boolean isValid() {
+        if (withdrawalReason == null) {
+            return detail != null && !detail.isBlank() && detail.trim().length() <= 50;
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
@@ -2,24 +2,35 @@ package org.appjam.bongbaek.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.appjam.bongbaek.domain.member.enums.WithdrawalReason;
 
 public record WithdrawRequest (
-    @Schema(description = "탈퇴 사유 (없으면 null)", example = "INCONVENIENT")
+    @NotNull(message = "탈퇴 사유는 필수입니다.")
+    @Schema(
+        description = "탈퇴 사유 (INCONVENIENT/PRIVACY_CONCERN/RARELY_USED/BUG_OR_ERROR/NEW_ACCOUNT/OTHER)",
+        example = "INCONVENIENT"
+    )
     WithdrawalReason withdrawalReason,
 
-    @Schema(description = "자유 입력 사유 (reason이 null일 때 필수, 영문/한글/특수문자/공백 포함 최대 50자)")
+    @Schema(
+        description = "상세 사유 (OTHER 선택 시 1~50자 필수 입력)",
+        example = "서비스가너무좋아서그만탈주"
+    )
     @Size(max = 50, message = "상세 사유는 50자 이내로 입력해주세요.")
     String detail
 ) {
     // 검증 단계
-    @AssertTrue(message = "사전 정의 사유를 선택하거나 상세 사유를 1~50자 입력해야 합니다.")
+    @AssertTrue(message = "사유가 OTHER인 경우 상세 사유를 1~50자로 입력해야 합니다. OTHER가 아니면 상세 사유를 null로 보내야 합니다.")
     @Schema(hidden = true)
-    public boolean isValid() {
-        if (withdrawalReason == null) {
+    public boolean isDetailValidWhenOther() {
+        if (withdrawalReason == WithdrawalReason.OTHER) {
+            // OTHER → detail 필수 (1~50자)
             return detail != null && !detail.isBlank() && detail.trim().length() <= 50;
+        } else {
+            // OTHER가 아닐 때 → detail 반드시 null
+            return detail == null;
         }
-        return true;
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/WithdrawRequest.java
@@ -1,9 +1,9 @@
 package org.appjam.bongbaek.domain.member.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.appjam.bongbaek.domain.member.entity.MemberWithdrawal;
 import org.appjam.bongbaek.domain.member.enums.WithdrawalReason;
 
 public record WithdrawRequest (
@@ -21,16 +21,10 @@ public record WithdrawRequest (
     @Size(max = 50, message = "상세 사유는 50자 이내로 입력해주세요.")
     String detail
 ) {
-    // 검증 단계
-    @AssertTrue(message = "사유가 OTHER인 경우 상세 사유를 1~50자로 입력해야 합니다. OTHER가 아니면 상세 사유를 null로 보내야 합니다.")
-    @Schema(hidden = true)
-    public boolean isDetailValidWhenOther() {
-        if (withdrawalReason == WithdrawalReason.OTHER) {
-            // OTHER → detail 필수 (1~50자)
-            return detail != null && !detail.isBlank() && detail.trim().length() <= 50;
-        } else {
-            // OTHER가 아닐 때 → detail 반드시 null
-            return detail == null;
-        }
+    public MemberWithdrawal toEntity() {
+        return MemberWithdrawal.builder()
+            .withdrawalReason(withdrawalReason)
+            .detail(detail)
+            .build();
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -8,11 +8,13 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.appjam.bongbaek.domain.common.BaseEntity;
-import org.appjam.bongbaek.domain.member.dto.WithdrawRequest;
 import org.appjam.bongbaek.domain.member.enums.WithdrawalReason;
+import org.appjam.bongbaek.global.common.CommonErrorCode;
+import org.appjam.bongbaek.global.exception.CustomException;
 import org.hibernate.annotations.Comment;
 
 @Entity
@@ -34,14 +36,20 @@ public class MemberWithdrawal extends BaseEntity {
     @Column(name = "detail", length = 150)
     private String detail;
 
-    public MemberWithdrawal(WithdrawRequest request) {
-        this.withdrawalReason = request.withdrawalReason();
-
-        // reason이 없을 때만 detail 저장
-        if (this.withdrawalReason == WithdrawalReason.OTHER) {
-            this.detail = (request.detail() == null) ? null : request.detail().trim();
+    @Builder
+    private MemberWithdrawal(WithdrawalReason withdrawalReason, String detail) {
+        if (withdrawalReason == WithdrawalReason.OTHER) {
+            String trimmed = detail == null ? null : detail.trim();
+            if (trimmed == null || trimmed.isBlank() || trimmed.length() > 50) {
+                throw new CustomException(CommonErrorCode.INVALID_WITHDRAWAL_DETAIL);
+            }
+            this.detail = trimmed;
         } else {
+            if (detail != null) {
+                throw new CustomException(CommonErrorCode.WITHDRAWAL_DETAIL_NOT_ALLOWED);
+            }
             this.detail = null;
         }
+        this.withdrawalReason = withdrawalReason;
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -1,0 +1,51 @@
+package org.appjam.bongbaek.domain.member.entity;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.appjam.bongbaek.domain.common.BaseEntity;
+import org.appjam.bongbaek.domain.member.dto.WithdrawRequest;
+import org.appjam.bongbaek.domain.member.enums.WithdrawalReason;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Table(name = "member_withdrawal")
+@Comment("회원 탈퇴 이력")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberWithdrawal extends BaseEntity {
+
+    @Id
+    @Tsid
+    @Column(name = "withdrawal_id", length = 13)
+    private String withdrawalId;
+
+    @Column(name = "member_id", nullable = false, length = 13)
+    private String memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "withdrawal_reason", columnDefinition = "VARCHAR(50)")
+    private WithdrawalReason withdrawalReason;
+
+    @Column(name = "detail", length = 150)
+    private String detail;
+
+    public MemberWithdrawal(String memberId, WithdrawRequest request) {
+        this.memberId = memberId;
+        this.withdrawalReason = request.withdrawalReason();
+
+        // reason이 없을 때만 detail 저장
+        if (this.withdrawalReason == null) {
+            this.detail = (request.detail() == null) ? null : request.detail().trim();
+        } else {
+            this.detail = null;
+        }
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -38,7 +38,7 @@ public class MemberWithdrawal extends BaseEntity {
         this.withdrawalReason = request.withdrawalReason();
 
         // reason이 없을 때만 detail 저장
-        if (this.withdrawalReason == null) {
+        if (this.withdrawalReason == WithdrawalReason.OTHER) {
             this.detail = (request.detail() == null) ? null : request.detail().trim();
         } else {
             this.detail = null;

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -27,9 +27,6 @@ public class MemberWithdrawal extends BaseEntity {
     @Column(name = "withdrawal_id", length = 13)
     private String withdrawalId;
 
-    @Column(name = "member_id", nullable = false, length = 30)
-    private String memberId;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "withdrawal_reason", columnDefinition = "VARCHAR(50)")
     private WithdrawalReason withdrawalReason;
@@ -37,8 +34,7 @@ public class MemberWithdrawal extends BaseEntity {
     @Column(name = "detail", length = 150)
     private String detail;
 
-    public MemberWithdrawal(String memberId, WithdrawRequest request) {
-        this.memberId = memberId;
+    public MemberWithdrawal(WithdrawRequest request) {
         this.withdrawalReason = request.withdrawalReason();
 
         // reason이 없을 때만 detail 저장

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -38,18 +38,26 @@ public class MemberWithdrawal extends BaseEntity {
 
     @Builder
     private MemberWithdrawal(WithdrawalReason withdrawalReason, String detail) {
-        if (withdrawalReason == WithdrawalReason.OTHER) {
+        this.withdrawalReason = withdrawalReason;
+        this.detail = validateAndNormalizeDetail(withdrawalReason, detail);
+    }
+
+    /**
+     * 탈퇴 사유와 상세 사유를 검증
+     */
+    private String validateAndNormalizeDetail(WithdrawalReason reason, String detail) {
+        if (reason == WithdrawalReason.OTHER) {
             String trimmed = detail == null ? null : detail.trim();
             if (trimmed == null || trimmed.isBlank() || trimmed.length() > 50) {
                 throw new CustomException(CommonErrorCode.INVALID_WITHDRAWAL_DETAIL);
             }
-            this.detail = trimmed;
-        } else {
-            if (detail != null) {
-                throw new CustomException(CommonErrorCode.WITHDRAWAL_DETAIL_NOT_ALLOWED);
-            }
-            this.detail = null;
+            return trimmed;
         }
-        this.withdrawalReason = withdrawalReason;
+
+        if (detail != null) {
+            throw new CustomException(CommonErrorCode.WITHDRAWAL_DETAIL_NOT_ALLOWED);
+        }
+
+        return null;
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -39,13 +39,13 @@ public class MemberWithdrawal extends BaseEntity {
     @Builder
     private MemberWithdrawal(WithdrawalReason withdrawalReason, String detail) {
         this.withdrawalReason = withdrawalReason;
-        this.detail = validateAndNormalizeDetail(withdrawalReason, detail);
+        this.detail = validateWithdrawalDetail(withdrawalReason, detail);
     }
 
     /**
      * 탈퇴 사유와 상세 사유를 검증
      */
-    private String validateAndNormalizeDetail(WithdrawalReason reason, String detail) {
+    private String validateWithdrawalDetail(WithdrawalReason reason, String detail) {
         if (reason == WithdrawalReason.OTHER) {
             String trimmed = detail == null ? null : detail.trim();
             if (trimmed == null || trimmed.isBlank() || trimmed.length() > 50) {

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -27,7 +27,7 @@ public class MemberWithdrawal extends BaseEntity {
     @Column(name = "withdrawal_id", length = 13)
     private String withdrawalId;
 
-    @Column(name = "member_id", nullable = false, length = 13)
+    @Column(name = "member_id", nullable = false, length = 30)
     private String memberId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/MemberWithdrawal.java
@@ -30,7 +30,7 @@ public class MemberWithdrawal extends BaseEntity {
     private String withdrawalId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "withdrawal_reason", columnDefinition = "VARCHAR(50)")
+    @Column(name = "withdrawal_reason", nullable = false, columnDefinition = "VARCHAR(50)")
     private WithdrawalReason withdrawalReason;
 
     @Column(name = "detail", length = 150)

--- a/src/main/java/org/appjam/bongbaek/domain/member/enums/WithdrawalReason.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/enums/WithdrawalReason.java
@@ -1,9 +1,20 @@
 package org.appjam.bongbaek.domain.member.enums;
 
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "회원 탈퇴 사유")
 public enum WithdrawalReason {
-    INCONVENIENT,
-    PRIVACY_CONCERN,
-    RARELY_USED,
-    BUG_OR_ERROR,
-    NEW_ACCOUNT
+    INCONVENIENT("이용이 불편함"),
+    PRIVACY_CONCERN("개인정보/보안 우려"),
+    RARELY_USED("이용 빈도가 낮음"),
+    BUG_OR_ERROR("버그/오류 발생"),
+    NEW_ACCOUNT("새 계정 생성"),
+    OTHER("기타(상세 사유 입력 필수)");
+
+    private final String description;
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/enums/WithdrawalReason.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/enums/WithdrawalReason.java
@@ -1,6 +1,6 @@
-package org.appjam.bongbaek.domain.member.enums
+package org.appjam.bongbaek.domain.member.enums;
 
-enum class WithdrawalReason {
+public enum WithdrawalReason {
     INCONVENIENT,
     PRIVACY_CONCERN,
     RARELY_USED,

--- a/src/main/java/org/appjam/bongbaek/domain/member/enums/WithdrawalReason.kt
+++ b/src/main/java/org/appjam/bongbaek/domain/member/enums/WithdrawalReason.kt
@@ -1,0 +1,9 @@
+package org.appjam.bongbaek.domain.member.enums
+
+enum class WithdrawalReason {
+    INCONVENIENT,
+    PRIVACY_CONCERN,
+    RARELY_USED,
+    BUG_OR_ERROR,
+    NEW_ACCOUNT
+}

--- a/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberWithdrawalRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/repository/MemberWithdrawalRepository.java
@@ -1,0 +1,9 @@
+package org.appjam.bongbaek.domain.member.repository;
+
+import org.appjam.bongbaek.domain.member.entity.MemberWithdrawal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberWithdrawalRepository extends JpaRepository<MemberWithdrawal, String> {
+}

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -145,28 +145,28 @@ public class MemberService {
     }
 
     @Transactional
-    public void withdraw(final String authorization, final String memberId, final WithdrawRequest request) {
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
+    public void withdraw(final String accessToken, final String memberId, final WithdrawRequest request) {
+        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
             throw new CustomException(CommonErrorCode.UNAUTHORIZED);
         }
 
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
 
-        final String accessToken = authorization.substring(7);
+        final String accessTokenNoBearer = accessToken.substring(7);
 
         // 유효성 검증 실패시 예외
-        jwtValidator.validateToken(accessToken);
+        jwtValidator.validateToken(accessTokenNoBearer);
 
         // 토큰 주체와 사용자 일치 확인
-        final String subject = jwtParser.parseClaims(accessToken).getSubject();
+        final String subject = jwtParser.parseClaims(accessTokenNoBearer).getSubject();
 
         if (!memberId.equals(subject)) {
             throw new CustomException(CommonErrorCode.UNAUTHORIZED);
         }
 
         // 토큰 무효화 (accessToken 블랙리스트 + refreshToken 전부 삭제)
-        jwtBlacklistManager.add(authorization);
+        jwtBlacklistManager.add(accessToken);
         jwtRefreshStore.deleteAllForUser(memberId);
 
         // 탈퇴 이력 저장

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -170,7 +170,7 @@ public class MemberService {
         jwtRefreshStore.deleteAllForUser(memberId);
 
         // 탈퇴 이력 저장
-        memberWithdrawalRepository.save(new MemberWithdrawal(memberId, request));
+        memberWithdrawalRepository.save(new MemberWithdrawal(request));
 
         // 회원 정보 삭제
         memberRepository.delete(member);

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package org.appjam.bongbaek.domain.member.service;
 
+import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,7 @@ public class MemberService {
     private final JwtParser jwtParser;
     private final JwtRefreshStore jwtRefreshStore;
     private final JwtBlacklistManager jwtBlacklistManager;
+    private final EntityManager entityManager;
 
     @Transactional
     public LoginResponse login(
@@ -86,7 +88,7 @@ public class MemberService {
 
     @Transactional
     public void logout(final String accessToken) {
-        if (accessToken == null || !accessToken.startsWith("Bearer ")) return;
+        if (!jwtValidator.isBearer(accessToken)) return;
 
         String accessTokenNoBearer = accessToken.substring("Bearer ".length());
         jwtValidator.validateToken(accessTokenNoBearer);
@@ -146,7 +148,7 @@ public class MemberService {
 
     @Transactional
     public void withdraw(final String accessToken, final String memberId, final WithdrawRequest request) {
-        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
+        if (!jwtValidator.isBearer(accessToken)) {
             throw new CustomException(CommonErrorCode.UNAUTHORIZED);
         }
 
@@ -165,14 +167,16 @@ public class MemberService {
             throw new CustomException(CommonErrorCode.UNAUTHORIZED);
         }
 
-        // 토큰 무효화 (accessToken 블랙리스트 + refreshToken 전부 삭제)
-        jwtBlacklistManager.add(accessToken);
-        jwtRefreshStore.deleteAllForUser(memberId);
-
         // 탈퇴 이력 저장
-        memberWithdrawalRepository.save(new MemberWithdrawal(request));
+        memberWithdrawalRepository.save(request.toEntity());
 
         // 회원 정보 삭제
         memberRepository.delete(member);
+
+        entityManager.flush();
+
+        // 토큰 무효화 (accessToken 블랙리스트 + refreshToken 전부 삭제)
+        jwtBlacklistManager.add(accessToken);
+        jwtRefreshStore.deleteAllForUser(memberId);
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -6,9 +6,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.appjam.bongbaek.domain.member.dto.LoginResponse;
 import org.appjam.bongbaek.domain.member.dto.SignUpRequest;
 import org.appjam.bongbaek.domain.member.dto.UpdateMemberRequest;
+import org.appjam.bongbaek.domain.member.dto.WithdrawRequest;
 import org.appjam.bongbaek.domain.member.entity.IncomeType;
 import org.appjam.bongbaek.domain.member.entity.Member;
+import org.appjam.bongbaek.domain.member.entity.MemberWithdrawal;
 import org.appjam.bongbaek.domain.member.repository.MemberRepository;
+import org.appjam.bongbaek.domain.member.repository.MemberWithdrawalRepository;
 import org.appjam.bongbaek.global.common.CommonErrorCode;
 import org.appjam.bongbaek.global.exception.CustomException;
 import org.appjam.bongbaek.global.exception.SignUpRequiredException;
@@ -30,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final MemberWithdrawalRepository memberWithdrawalRepository;
+
     private final KakaoLoginClient kakaoLoginClient;
 
     private final JwtProvider jwtProvider;
@@ -137,5 +142,37 @@ public class MemberService {
             .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
 
         member.update(request);
+    }
+
+    @Transactional
+    public void withdraw(final String authorization, final String memberId, final WithdrawRequest request) {
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            throw new CustomException(CommonErrorCode.UNAUTHORIZED);
+        }
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(CommonErrorCode.MEMBER_NOT_FOUND));
+
+        final String accessToken = authorization.substring(7);
+
+        // 유효성 검증 실패시 예외
+        jwtValidator.validateToken(accessToken);
+
+        // 토큰 주체와 사용자 일치 확인
+        final String subject = jwtParser.parseClaims(accessToken).getSubject();
+
+        if (!memberId.equals(subject)) {
+            throw new CustomException(CommonErrorCode.UNAUTHORIZED);
+        }
+
+        // 토큰 무효화 (accessToken 블랙리스트 + refreshToken 전부 삭제)
+        jwtBlacklistManager.add(authorization);
+        jwtRefreshStore.deleteAllForUser(memberId);
+
+        // 탈퇴 이력 저장
+        memberWithdrawalRepository.save(new MemberWithdrawal(memberId, request));
+
+        // 회원 정보 삭제
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/common/CommonErrorCode.java
@@ -11,6 +11,9 @@ public enum CommonErrorCode implements ErrorCode {
     ALREADY_REGISTERED_MEMBER(false, HttpStatus.BAD_REQUEST, "이미 가입된 사용자입니다."),
     NULL_POINTER_ERROR(false, HttpStatus.BAD_REQUEST, "필수 요청 값이 비어있습니다."),
 
+    INVALID_WITHDRAWAL_DETAIL(false, HttpStatus.BAD_REQUEST, "사유가 OTHER인 경우 상세 사유를 1~50자로 입력해야 합니다."),
+    WITHDRAWAL_DETAIL_NOT_ALLOWED(false, HttpStatus.BAD_REQUEST, "사유가 OTHER이 아닌 경우 상세 사유를 null로 보내야 합니다."),
+
     // 401 Unauthorized
     UNAUTHORIZED(false, HttpStatus.UNAUTHORIZED,"인증에 실패했습니다."),
     INVALID_ACCESS_TOKEN(false, HttpStatus.UNAUTHORIZED, "유효하지 않은 Access Token입니다."),

--- a/src/main/java/org/appjam/bongbaek/global/jwt/components/JwtValidator.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/components/JwtValidator.java
@@ -39,4 +39,11 @@ public class JwtValidator {
             throw new CustomException(CommonErrorCode.INVALID_ACCESS_TOKEN);
         }
     }
+
+    /**
+     * 토큰이 Bearer로 시작하는지 확인
+     */
+    public boolean isBearer(String token) {
+        return token != null && token.startsWith("Bearer ");
+    }
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #62 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 회원 탈퇴 기능을 구현합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] MemberWithdrawal 엔티티 작성
- [x] WithdrawRequest dto 작성
- [x] MemberWithdrawalRepository 작성
- [x] 탈퇴 request에 @Schema(hidden = true) 추가
- [x] 탈퇴 api controller 작성
- [x] 탈퇴 api service 작성

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내용

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 계정 탈퇴 API 추가: 인증 후 POST로 탈퇴 요청 가능, 사유 선택(사전 목록) 및 OTHER 선택 시 상세 사유 입력 검증 포함.
  * 탈퇴 이력 저장 및 즉시 로그아웃 처리: 액세스/리프레시 토큰 무효화로 접근 차단.

* **문서**
  * 탈퇴 API 문서화: 선택 가능한 사유와 OTHER일 경우 상세 사유 입력 조건(최대 길이) 명시.

* **오류 메시지**
  * 상세 사유 입력 검증 관련 클라이언트 오류 코드/메시지 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->