### PR TITLE
[HOTFIX] 회원 정보 수정/탈퇴/로그아웃 null -> x 로

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -76,13 +76,13 @@ public class MemberController {
 
     @Operation(summary = "로그아웃", description = "현재 사용자의 모든 리프레시 토큰을 무효화합니다.")
     @PostMapping("/member/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(
+    public ResponseEntity<ApiResponse<EmptyBody>> logout(
         @RequestHeader("Authorization") String accessToken
     ) {
         memberService.logout(accessToken);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ApiResponse.success(CommonSuccessCode.OK, null));
+            .body(ApiResponse.success(CommonSuccessCode.OK));
     }
 
 
@@ -107,7 +107,7 @@ public class MemberController {
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(ApiResponse.success(CommonSuccessCode.OK, null));
+            .body(ApiResponse.success(CommonSuccessCode.OK));
     }
 
     @Operation(
@@ -129,7 +129,7 @@ public class MemberController {
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(ApiResponse.success(CommonSuccessCode.OK, null));
+            .body(ApiResponse.success(CommonSuccessCode.OK));
     }
 
     @Operation(summary = "마이페이지 회원 정보 조회", description = "마이페이지 속 이름/생일/소득을 조회합니다. 소득 구간 OVER200: 월 소득 200만원 이상, UNDER200: 월 소득 200만원 미만, NONE: 없음")

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/request/WithdrawRequest.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/request/WithdrawRequest.java
@@ -10,7 +10,7 @@ public record WithdrawRequest (
     @NotNull(message = "탈퇴 사유는 필수입니다.")
     @Schema(
         description = "탈퇴 사유 (INCONVENIENT/PRIVACY_CONCERN/RARELY_USED/BUG_OR_ERROR/NEW_ACCOUNT/OTHER)",
-        example = "INCONVENIENT"
+        example = "OTHER"
     )
     WithdrawalReason withdrawalReason,
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #번호

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 클라이언트의 요청에 따라 회원 정보 수정/탈퇴/로그아웃 null -> x 로 수정합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 회원 정보 수정/탈퇴/로그아웃 null -> x 로 

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내용

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 해당 없음
- 리팩터: 로그아웃, 프로필 수정, 회원탈퇴 API의 성공 응답을 빈 본문으로 통일하여 불필요한 null 값 제거(HTTP 200 유지). 클라이언트 체감 기능 변화 없음.
- 문서: 회원탈퇴 사유 예시 값을 “OTHER”로 업데이트해 API 문서 명확성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->