### PR TITLE
[FIX] 응답 구조 수정

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/controller/MemberController.java
@@ -76,13 +76,13 @@ public class MemberController {
 
     @Operation(summary = "로그아웃", description = "현재 사용자의 모든 리프레시 토큰을 무효화합니다.")
     @PostMapping("/member/logout")
-    public ResponseEntity<ApiResponse<EmptyBody>> logout(
+    public ResponseEntity<ApiResponse<Void>> logout(
         @RequestHeader("Authorization") String accessToken
     ) {
         memberService.logout(accessToken);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ApiResponse.success(CommonSuccessCode.OK));
+            .body(ApiResponse.success(CommonSuccessCode.OK, null));
     }
 
 
@@ -99,7 +99,7 @@ public class MemberController {
 
     @Operation(summary = "회원 프로필 수정", description = "이름/생일/소득을 전달하여 프로필을 전체 교체합니다.")
     @PutMapping(path = "/member/profile")
-    public ResponseEntity<ApiResponse<EmptyBody>> updateProfile(
+    public ResponseEntity<ApiResponse<Void>> updateProfile(
         @AuthenticationPrincipal final String memberId,
         @RequestBody @Valid final UpdateMemberRequest request
     ) {
@@ -107,7 +107,7 @@ public class MemberController {
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(ApiResponse.success(CommonSuccessCode.OK));
+            .body(ApiResponse.success(CommonSuccessCode.OK,null));
     }
 
     @Operation(
@@ -120,7 +120,7 @@ public class MemberController {
         """
     )
     @PostMapping("/member/withdraw")
-    public ResponseEntity<ApiResponse<EmptyBody>> withdraw(
+    public ResponseEntity<ApiResponse<Void>> withdraw(
         @RequestHeader(value = "Authorization") final String accessToken,
         @AuthenticationPrincipal final String memberId,
         @Valid @RequestBody final WithdrawRequest request
@@ -129,7 +129,7 @@ public class MemberController {
 
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(ApiResponse.success(CommonSuccessCode.OK));
+            .body(ApiResponse.success(CommonSuccessCode.OK, null));
     }
 
     @Operation(summary = "마이페이지 회원 정보 조회", description = "마이페이지 속 이름/생일/소득을 조회합니다. 소득 구간 OVER200: 월 소득 200만원 이상, UNDER200: 월 소득 200만원 미만, NONE: 없음")

--- a/src/main/java/org/appjam/bongbaek/domain/member/dto/request/LoginResponse.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/dto/request/LoginResponse.java
@@ -3,34 +3,44 @@ package org.appjam.bongbaek.domain.member.dto.request;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.appjam.bongbaek.global.jwt.dto.TokenResponse;
+import org.springframework.beans.factory.annotation.Value;
 
 public record LoginResponse(
         @Schema(description = "회원 이름")
         String name,
+
         @Schema(description = "jwt Token", nullable = true)
         TokenResponse token,
+
         @Schema(description = "회원 가입 완료 여부")
         boolean isCompletedSignUp,
+
         @Schema(description = "kakao ID", nullable = true)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String kakaoId,
+
         @Schema(description = "apple ID", nullable = true)
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        String appleId
+        String appleId,
+
+        @Schema(description = "kakao map api key", nullable = true)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String apiKey
 ) {
     public static LoginResponse ofKakaoLoginFailure(final String kakaoId) {
-        return new LoginResponse(null, null, false, kakaoId, null);
+        return new LoginResponse(null, null, false, kakaoId, null, null);
     }
 
     public static LoginResponse ofAppleLoginFailure(final String appleId) {
-        return new LoginResponse(null, null, false, null, appleId);
+        return new LoginResponse(null, null, false, null, appleId, null);
     }
 
-    public static LoginResponse ofKakaoLoginSuccess(final String name, final TokenResponse token, final String kakaoId) {
-        return new LoginResponse(name, token, true, kakaoId, null);
+    public static LoginResponse ofKakaoLoginSuccess(final String name, final TokenResponse token, final String kakaoId, final String apiKey) {
+
+        return new LoginResponse(name, token, true, kakaoId, null, apiKey);
     }
 
-    public static LoginResponse ofAppleLoginSuccess(final String name, final TokenResponse token, final String appleId) {
-        return new LoginResponse(name, token, true, null, appleId);
+    public static LoginResponse ofAppleLoginSuccess(final String name, final TokenResponse token, final String appleId, final String apiKey) {
+        return new LoginResponse(name, token, true, null, appleId, apiKey);
     }
 }

--- a/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/entity/Member.java
@@ -45,9 +45,12 @@ public class Member {
 	@Column(name = "kakao_id", updatable = false)
 	private String kakaoId;
 
+	@Column(name = "google_id", updatable = false)
+	private String googleId;
+
 	@Builder
-	private Member(String memberName, LocalDate memberBirthday, IncomeType memberIncome, String appleId, String kakaoId) {
-		if ((appleId == null) == (kakaoId == null)) {
+	private Member(String memberName, LocalDate memberBirthday, IncomeType memberIncome, String appleId, String kakaoId, String googleId) {
+		if ((appleId == null) && (kakaoId == null) && (googleId == null)) {
 			throw new CustomException(CommonErrorCode.INVALID_OAUTH_ACCOUNT);
 			}
 		this.memberName = memberName;
@@ -55,6 +58,7 @@ public class Member {
 		this.memberIncome = memberIncome;
 		this.appleId = appleId;
 		this.kakaoId = kakaoId;
+		this.googleId = googleId;
 	}
 
     public void update(UpdateMemberRequest request){

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -24,6 +24,7 @@ import org.appjam.bongbaek.global.jwt.components.JwtProvider;
 import org.appjam.bongbaek.global.jwt.components.JwtValidator;
 import org.appjam.bongbaek.global.oauth.apple.AppleLoginClient;
 import org.appjam.bongbaek.global.oauth.kakao.KakaoLoginClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +46,9 @@ public class MemberService {
     private final JwtBlacklistManager jwtBlacklistManager;
     private final EntityManager entityManager;
 
+    @Value("${kakao-api.key}")
+    private String apiKey;
+
     @Transactional
     public LoginResponse login(
             OAuthProvider oAuthProvider,
@@ -59,7 +63,7 @@ public class MemberService {
 
                 TokenResponse tokenResponse = generateTokensForMember(member);
 
-                return LoginResponse.ofKakaoLoginSuccess(member.getMemberName(), tokenResponse, kakaoId);
+                return LoginResponse.ofKakaoLoginSuccess(member.getMemberName(), tokenResponse, kakaoId, apiKey);
             } catch(SignUpRequiredException e){
                 return LoginResponse.ofKakaoLoginFailure(kakaoId);
             }
@@ -74,7 +78,7 @@ public class MemberService {
 
                 TokenResponse tokenResponse = generateTokensForMember(member);
 
-                return LoginResponse.ofAppleLoginSuccess(member.getMemberName(), tokenResponse, appleId);
+                return LoginResponse.ofAppleLoginSuccess(member.getMemberName(), tokenResponse, appleId, apiKey);
             } catch(SignUpRequiredException e){
                 return LoginResponse.ofAppleLoginFailure(appleId);
             }
@@ -96,7 +100,7 @@ public class MemberService {
             TokenResponse tokenResponse = generateTokensForMember(member);
             log.info("회원가입 완료. 카카오 ID: {}", signUpRequest.kakaoId());
 
-            return LoginResponse.ofKakaoLoginSuccess(member.getMemberName(), tokenResponse, signUpRequest.kakaoId());
+            return LoginResponse.ofKakaoLoginSuccess(member.getMemberName(), tokenResponse, signUpRequest.kakaoId(), apiKey);
         }
 
         if(signUpRequest.appleId() != null && !signUpRequest.appleId().isEmpty()) {
@@ -108,7 +112,7 @@ public class MemberService {
             TokenResponse tokenResponse = generateTokensForMember(member);
             log.info("회원가입 완료. 애플 ID: {}", signUpRequest.appleId());
 
-            return LoginResponse.ofAppleLoginSuccess(member.getMemberName(), tokenResponse, signUpRequest.appleId());
+            return LoginResponse.ofAppleLoginSuccess(member.getMemberName(), tokenResponse, signUpRequest.appleId(), apiKey);
         }
 
         throw new CustomException(CommonErrorCode.UNAUTHORIZED);

--- a/src/main/java/org/appjam/bongbaek/global/api/ApiResponse.java
+++ b/src/main/java/org/appjam/bongbaek/global/api/ApiResponse.java
@@ -14,8 +14,8 @@ public record ApiResponse<T>(
         T data
 ) {
     // response body 없는 버전
-    public static <T> ApiResponse<EmptyBody> success(SuccessCode successCode) {
-        return new ApiResponse<EmptyBody>(successCode.getSuccess(), successCode.getStatus().value(), successCode.getMessage(), new EmptyBody());
+    public static <T> ApiResponse<T> success(SuccessCode successCode) {
+        return new ApiResponse<T>(successCode.getSuccess(), successCode.getStatus().value(), successCode.getMessage(), null);
     }
 
     // response body 있는 버전


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #71 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 로그인 성공 시 응답에 api키를 추가합니다.
- 응답에서 data에 빈 객체가 설정되는 기능을 원상복구합니다.
- 구현 예정인 구글 로그인에 대한 식별자 필드를 엔티티에 추가합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 로그인 성공 응답에 api키 추가
- [x] 구글 로그인 식별자 추가

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 응답에 api키가 포함되어 있으므로 생략합니다

## 💬 리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인 응답에 카카오 지도 API 키(apiKey) 포함되어 클라이언트에서 지도 기능을 바로 활용 가능.
  - 구글 계정 식별자 추가로 향후 구글 로그인 지원 기반 마련.

- 변경 사항
  - 로그아웃/프로필 수정/회원탈퇴 응답에서 빈 데이터 필드 제거로 응답 포맷 간소화(data 미포함). 기능 동작에는 영향 없음.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->