### PR TITLE
[REFAC] 객체 생성 및 공통 응답 필드 수정

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/CostCalculator.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/CostCalculator.java
@@ -8,7 +8,11 @@ import org.appjam.bongbaek.domain.member.entity.IncomeType;
 import org.appjam.bongbaek.domain.member.entity.Member;
 import org.appjam.bongbaek.global.exception.common.RequestInvalidException;
 
-public class CostCalculator {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CostCalculator {
 	private static final int UNIT_AMOUNT = 10000;
 
 	// 나이 계수 상수

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/RangeCalculator.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/RangeCalculator.java
@@ -2,7 +2,11 @@ package org.appjam.bongbaek.domain.event.service.util;
 
 import org.appjam.bongbaek.domain.event.service.util.vo.RangeInfo;
 
-public class RangeCalculator {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RangeCalculator {
 	public static RangeInfo calculateRange(int cost) {
 		if (cost <= 30_000) {
 			return new RangeInfo(10_000, 50_000);

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/util/Validator.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/util/Validator.java
@@ -5,7 +5,11 @@ import org.appjam.bongbaek.global.exception.common.RequestInvalidException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Validator {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class Validator {
     // 하나의 시각적 유니코드 grapheme의 정규식인 "\X"를 이용하여 문자열의 길이를 카운트
     private static final Pattern GRAPHEME_PATTERN = Pattern.compile("\\X");
 

--- a/src/main/java/org/appjam/bongbaek/global/api/code/ErrorResultCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/api/code/ErrorResultCode.java
@@ -1,7 +1,7 @@
 package org.appjam.bongbaek.global.api.code;
 
+/**
+ * 실패 응답 마커 인터페이스
+ */
 public interface ErrorResultCode extends ResultCode {
-	default boolean isSuccess() {
-		return false;
-	}
 }

--- a/src/main/java/org/appjam/bongbaek/global/api/code/SuccessResultCode.java
+++ b/src/main/java/org/appjam/bongbaek/global/api/code/SuccessResultCode.java
@@ -1,7 +1,7 @@
 package org.appjam.bongbaek.global.api.code;
 
+/**
+ * 성공 응답 마커 인터페이스
+ */
 public interface SuccessResultCode extends ResultCode {
-	default boolean isSuccess() {
-		return true;
-	}
 }

--- a/src/main/java/org/appjam/bongbaek/global/api/response/ApiResponse.java
+++ b/src/main/java/org/appjam/bongbaek/global/api/response/ApiResponse.java
@@ -7,17 +7,19 @@ public interface ApiResponse {
 
 	int status();
 
+	String code();
+
 	String message();
 
 	static <T> SuccessResponse<T> success(SuccessResultCode successCode, T data) {
-		return new SuccessResponse<T>(true, successCode.getStatus().value(), successCode.getMessage(), data);
+		return SuccessResponse.of(successCode, data);
 	}
 
 	static <T> SuccessResponse<T> success(SuccessResultCode successCode) {
-		return new SuccessResponse<T>(true, successCode.getStatus().value(), successCode.getMessage(), null);
+		return SuccessResponse.of(successCode);
 	}
 
 	static FailureResponse failure(ErrorResultCode errorCode) {
-		return new FailureResponse(false, errorCode.getStatus().value(), errorCode.getMessage());
+		return FailureResponse.of(errorCode);
 	}
 }

--- a/src/main/java/org/appjam/bongbaek/global/api/response/FailureResponse.java
+++ b/src/main/java/org/appjam/bongbaek/global/api/response/FailureResponse.java
@@ -1,8 +1,16 @@
 package org.appjam.bongbaek.global.api.response;
 
+import org.appjam.bongbaek.global.api.code.ErrorResultCode;
+
 public record FailureResponse(
-		boolean success,
 		int status,
+		String code,
 		String message
 ) implements ApiResponse {
+	public static FailureResponse of(ErrorResultCode errorCode) {
+		return new FailureResponse(
+				errorCode.getStatus().value(),
+				errorCode.toString(),
+				errorCode.getMessage());
+	}
 }

--- a/src/main/java/org/appjam/bongbaek/global/api/response/SuccessResponse.java
+++ b/src/main/java/org/appjam/bongbaek/global/api/response/SuccessResponse.java
@@ -1,9 +1,24 @@
 package org.appjam.bongbaek.global.api.response;
 
+import org.appjam.bongbaek.global.api.code.SuccessResultCode;
+
 public record SuccessResponse<T>(
-		boolean success,
 		int status,
+		String code,
 		String message,
 		T data
 ) implements ApiResponse {
+	public static <T> SuccessResponse<T> of(SuccessResultCode successCode, T data) {
+		return new SuccessResponse<>(
+				successCode.getStatus().value(),
+				successCode.toString(),
+				successCode.getMessage(), data);
+	}
+
+	public static <T> SuccessResponse<T> of(SuccessResultCode successCode) {
+		return new SuccessResponse<>(
+				successCode.getStatus().value(),
+				successCode.toString(),
+				successCode.getMessage(), null);
+	}
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #78 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 유틸 믈래스의 객체 생성 방식에 대한 리팩토링을 진행합니다.
- 공통 응답 구조의 필드에 대한 리팩토링을 진행합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] `util`객체의 인스턴스화 방지를 위한 private생성자 추가
- [x] 응답 시 사용하지 않는 필드 제거 및 에러 처리를 위한 `code`추가 

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 기존 결과와 동일하므로 생략합니다

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新 기능
  - API 응답에 코드 식별자(code) 추가로 상태 구분이 명확해졌습니다.
  - 성공/실패 응답을 간편 생성하는 정적 팩토리 메서드를 제공합니다.

- 리팩터링
  - 응답 스키마 변경: success 플래그 제거, 상태/코드/메시지 중심 구조로 통일되었습니다. 클라이언트는 code 필드 사용을 권장합니다.
  - 공용 응답 인터페이스에 코드 조회가 추가되었습니다.

- 문서
  - 성공/오류 결과 마커 인터페이스 설명 주석이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->