### PR TITLE
[FEAT] 월별 경조사 정보 조회 기능 구현

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
@@ -11,15 +11,19 @@ import org.appjam.bongbaek.domain.event.dto.response.EventListDto;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
 import org.appjam.bongbaek.global.api.response.SuccessResponse;
 
 @Tag(name = "경조사 정보", description = "경조사 정보 관련 API")
 public interface EventController {
 	@Operation(summary = "경조사 정보 생성", description = "경조사 정보 데이터를 생성합니다.")
-	SuccessResponse<Void> createEvent(String memberId, EventWriteDto eventWriteDto);
+	SuccessResponse<Void> createEvent(String memberId, @Valid EventWriteDto eventWriteDto);
 
 	@Operation(summary = "월별 경조사 정보 조회", description = "월별로 경조사 정보를 조회합니다.")
-	SuccessResponse<EventListDto> getMonthlyEvents(String memberId, int page, int year, int month, String category, Boolean attended);
+	SuccessResponse<EventListDto> getMonthlyEvents(String memberId, int page, int year, @Min(1) @Max(12) int month, String category, Boolean attended);
 
 	@Operation(summary = "과거 경조사 정보 조회", description = "조회 시점을 기준으로 과거의 경조사 정보를 조회합니다.")
 	SuccessResponse<EventListDto> getEventHistory(String memberId, int page, String category, Boolean attended);
@@ -28,7 +32,7 @@ public interface EventController {
 	SuccessResponse<EventListDto> getUpcomingEvents(String memberId, int page, String category);
 
 	@Operation(summary = "경조사 비용 추천", description = "경조사 정보와 사용자 정보를 기반으로 적절한 경조사 비용을 산정합니다.")
-	SuccessResponse<CostProposalResponseDto> createEventCost(String memberId, CostProposalRequestDto costProposalRequestDto);
+	SuccessResponse<CostProposalResponseDto> createEventCost(String memberId, @Valid CostProposalRequestDto costProposalRequestDto);
 
 	@Operation(summary = "경조사 정보 상세 조회", description = "단일 경조사 정보에 대한 상세 정보를 조회합니다.")
 	SuccessResponse<EventDetailResponseDto> getEventByEventId(String memberId, String eventId);
@@ -37,11 +41,11 @@ public interface EventController {
 	SuccessResponse<EventHomeResponseDto> getEventsForHome(String memberId);
 
 	@Operation(summary = "경조사 정보 수정", description = "단일 경조사 정보에 대한 내용을 수정합니다.")
-	SuccessResponse<Void> updateEvent(String memberId, String eventId, EventUpdateRequestDto eventUpdateRequestDto);
+	SuccessResponse<Void> updateEvent(String memberId, String eventId, @Valid EventUpdateRequestDto eventUpdateRequestDto);
 
 	@Operation(summary = "단일 경조사 정보 삭제", description = "단일 경조사 정보에 대한 데이터를 삭제합니다.")
 	SuccessResponse<Void> deleteEventByEventId(String memberId, String eventId);
 
 	@Operation(summary = "복수 경조사 정보 삭제", description = "여러 개의 경조사 정보에 대한 데이터를 삭제합니다.")
-	SuccessResponse<Void> deleteEvents(String memberId, EventDeleteRequestDto eventDeleteRequestDto);
+	SuccessResponse<Void> deleteEvents(String memberId, @Valid EventDeleteRequestDto eventDeleteRequestDto);
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
@@ -18,6 +18,9 @@ public interface EventController {
 	@Operation(summary = "경조사 정보 생성", description = "경조사 정보 데이터를 생성합니다.")
 	SuccessResponse<Void> createEvent(String memberId, EventWriteDto eventWriteDto);
 
+	@Operation(summary = "월별 경조사 정보 조회", description = "월별로 경조사 정보를 조회합니다.")
+	SuccessResponse<EventListDto> getMonthlyEvents(String memberId, int page, int year, int month, String category, Boolean attended);
+
 	@Operation(summary = "과거 경조사 정보 조회", description = "조회 시점을 기준으로 과거의 경조사 정보를 조회합니다.")
 	SuccessResponse<EventListDto> getEventHistory(String memberId, int page, String category, Boolean attended);
 

--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventController.java
@@ -2,6 +2,7 @@ package org.appjam.bongbaek.domain.event.controller;
 
 import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventDeleteRequestDto;
+import org.appjam.bongbaek.domain.event.dto.request.EventSearchRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventUpdateRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventWriteDto;
 import org.appjam.bongbaek.domain.event.dto.response.CostProposalResponseDto;
@@ -12,8 +13,6 @@ import org.appjam.bongbaek.domain.event.dto.response.EventListDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 
 import org.appjam.bongbaek.global.api.response.SuccessResponse;
 
@@ -23,7 +22,7 @@ public interface EventController {
 	SuccessResponse<Void> createEvent(String memberId, @Valid EventWriteDto eventWriteDto);
 
 	@Operation(summary = "월별 경조사 정보 조회", description = "월별로 경조사 정보를 조회합니다.")
-	SuccessResponse<EventListDto> getMonthlyEvents(String memberId, int page, int year, @Min(1) @Max(12) int month, String category, Boolean attended);
+	SuccessResponse<EventListDto> getMonthlyEvents(String memberId, int page, @Valid EventSearchRequestDto eventSearchRequestDto);
 
 	@Operation(summary = "과거 경조사 정보 조회", description = "조회 시점을 기준으로 과거의 경조사 정보를 조회합니다.")
 	SuccessResponse<EventListDto> getEventHistory(String memberId, int page, String category, Boolean attended);

--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
@@ -17,6 +17,7 @@ import org.appjam.bongbaek.global.api.code.event.SuccessCode;
 import org.appjam.bongbaek.global.api.response.ApiResponse;
 import org.appjam.bongbaek.global.api.response.SuccessResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,8 +28,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/events")
@@ -51,7 +55,7 @@ public class EventControllerImpl implements EventController {
 			@AuthenticationPrincipal final String memberId,
 			@PathVariable(name = "page") final int page,
 			@RequestParam(name = "year") final int year,
-			@RequestParam(name = "month") final int month,
+			@RequestParam(name = "month") @Min(1) @Max(12) final int month,
 			@RequestParam(name = "category", required = false) final String category,
 			@RequestParam(name = "attended", required = false) final Boolean attended
 	) {

--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 
 import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventDeleteRequestDto;
+import org.appjam.bongbaek.domain.event.dto.request.EventSearchRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventUpdateRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventWriteDto;
 import org.appjam.bongbaek.domain.event.dto.response.CostProposalResponseDto;
@@ -20,6 +21,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -54,13 +56,10 @@ public class EventControllerImpl implements EventController {
 	public SuccessResponse<EventListDto> getMonthlyEvents(
 			@AuthenticationPrincipal final String memberId,
 			@PathVariable(name = "page") final int page,
-			@RequestParam(name = "year") final int year,
-			@RequestParam(name = "month") @Min(1) @Max(12) final int month,
-			@RequestParam(name = "category", required = false) final String category,
-			@RequestParam(name = "attended", required = false) final Boolean attended
+			@ModelAttribute @Valid final EventSearchRequestDto eventSearchRequestDto
 	) {
 		return ApiResponse.success(SuccessCode.EVENT_FOUND,
-				eventService.getMonthlyEvents(memberId, page, category, attended, year, month));
+				eventService.getMonthlyEvents(memberId, page, eventSearchRequestDto));
 	}
 
 	@GetMapping(path = "/history/{page}")

--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
@@ -46,6 +46,19 @@ public class EventControllerImpl implements EventController {
 		return ApiResponse.success(SuccessCode.EVENT_CREATED);
 	}
 
+	@GetMapping(path = "/monthly/{page}")
+	public SuccessResponse<EventListDto> getMonthlyEvents(
+			@AuthenticationPrincipal final String memberId,
+			@PathVariable(name = "page") final int page,
+			@RequestParam(name = "year") final int year,
+			@RequestParam(name = "month") final int month,
+			@RequestParam(name = "category", required = false) final String category,
+			@RequestParam(name = "attended", required = false) final Boolean attended
+	) {
+		return ApiResponse.success(SuccessCode.EVENT_FOUND,
+				eventService.getMonthlyEvents(memberId, page, category, attended, year, month));
+	}
+
 	@GetMapping(path = "/history/{page}")
 	public SuccessResponse<EventListDto> getEventHistory(
 			@AuthenticationPrincipal final String memberId,

--- a/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/controller/EventControllerImpl.java
@@ -30,15 +30,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/events")
-public class EventControllerImpl {
+public class EventControllerImpl implements EventController {
 
 	private final EventService eventService;
 

--- a/src/main/java/org/appjam/bongbaek/domain/event/dto/request/EventSearchRequestDto.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/dto/request/EventSearchRequestDto.java
@@ -1,0 +1,13 @@
+package org.appjam.bongbaek.domain.event.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record EventSearchRequestDto(
+		int year,
+		@Min(1) @Max(12)
+		int month,
+		String category,
+		Boolean attended
+) {
+}

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface EventSearchRepository {
-	Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(String memberId, Category category, Boolean attended, Pageable pageable);
+	Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(String memberId, Category category,
+			Boolean attended, Pageable pageable);
 
 	Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(String memberId, Category category, Pageable pageable);
+
+	Slice<Event> findMonthlyEventsByMemberIdAndCategoryAndAttentedOrderBy(String memberId, int year, int month,
+			Category category, Boolean attended, Pageable pageable);
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepository.java
@@ -11,6 +11,6 @@ public interface EventSearchRepository {
 
 	Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(String memberId, Category category, Pageable pageable);
 
-	Slice<Event> findMonthlyEventsByMemberIdAndCategoryAndAttentedOrderBy(String memberId, int year, int month,
+	Slice<Event> findMonthlyEventsByMemberIdAndCategoryAndAttendedOrderBy(String memberId, int year, int month,
 			Category category, Boolean attended, Pageable pageable);
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -133,7 +133,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 		LocalDate monthStart = LocalDate.of(year, month, 1);
 		LocalDate monthEnd = monthStart.plusMonths(1);
 
-		return QEvent.event.eventDate.goe(LocalDate.from(monthStart.atStartOfDay()))
-				.and(QEvent.event.eventDate.lt(LocalDate.from(monthEnd.atStartOfDay())));
+		return QEvent.event.eventDate.goe(monthStart)
+				.and(QEvent.event.eventDate.lt(monthEnd));
 	}
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -70,7 +70,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 	}
 
 	@Override
-	public Slice<Event> findMonthlyEventsByMemberIdAndCategoryAndAttentedOrderBy(
+	public Slice<Event> findMonthlyEventsByMemberIdAndCategoryAndAttendedOrderBy(
 			String memberId,
 			int year,
 			int month,

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -2,6 +2,7 @@ package org.appjam.bongbaek.domain.event.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+
 import org.appjam.bongbaek.domain.event.entity.Category;
 import org.appjam.bongbaek.domain.event.entity.Event;
 import org.appjam.bongbaek.domain.event.entity.QEvent;
@@ -9,8 +10,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -20,7 +23,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 
 	@Override
 	public Slice<Event> findEventHistoryByMemberIdAndCategoryAndAttendedOrderBy(
-            String memberId,
+			String memberId,
 			Category category,
 			Boolean attended,
 			Pageable pageable
@@ -50,10 +53,10 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 
 	@Override
 	public Slice<Event> findUpcomingEventsByMemberIdAndCategoryOrderBy(
-        String memberId,
-        Category category,
-        Pageable pageable
-    ) {
+			String memberId,
+			Category category,
+			Pageable pageable
+	) {
 		QEvent qEvent = QEvent.event;
 		int pageSize = pageable.getPageSize();
 
@@ -76,17 +79,61 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 		return new SliceImpl<Event>(events, pageable, hasNext);
 	}
 
+	@Override
+	public Slice<Event> findMonthlyEventsByMemberIdAndCategoryAndAttentedOrderBy(
+			String memberId,
+			int year,
+			int month,
+			Category category,
+			Boolean attended,
+			Pageable pageable
+	) {
+		QEvent qEvent = QEvent.event;
+		int pageSize = pageable.getPageSize();
+
+		List<Event> events = queryFactory.selectFrom(qEvent)
+				.where(
+						qEvent.member.memberId.eq(memberId),
+						eventMonthEqual(year, month),
+						categoryEqual(category),
+						attendedEqual(attended)
+				)
+				.orderBy(qEvent.eventDate.desc())
+				.offset(pageable.getOffset())
+				.limit(pageSize + 1)
+				.fetch();
+
+		boolean hasNext = events.size() > pageSize;
+		if (hasNext) {
+			events.remove(pageSize);
+		}
+
+		return new SliceImpl<Event>(events, pageable, hasNext);
+	}
+
 	private BooleanExpression categoryEqual(Category category) {
-		if(category == null){
+		if (category == null) {
 			return null;
 		}
 		return QEvent.event.eventCategory.eq(category);
 	}
 
 	private BooleanExpression attendedEqual(Boolean attended) {
-		if(attended == null){
+		if (attended == null) {
 			return null;
 		}
 		return QEvent.event.attended.eq(attended);
+	}
+
+	private BooleanExpression eventMonthEqual(int year, int month) {
+		if (year == 0 || month == 0 || month > 12) {
+			return null;
+		}
+
+		LocalDate monthStart = LocalDate.of(year, month, 1);
+		LocalDate monthEnd = monthStart.plusMonths(1);
+
+		return QEvent.event.eventDate.goe(LocalDate.from(monthStart.atStartOfDay()))
+				.and(QEvent.event.eventDate.lt(LocalDate.from(monthEnd.atStartOfDay())));
 	}
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -93,12 +93,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 				.limit(pageSize + 1)
 				.fetch();
 
-		boolean hasNext = events.size() > pageSize;
-		if (hasNext) {
-			events.remove(pageSize);
-		}
-
-		return new SliceImpl<Event>(events, pageable, hasNext);
+		return toSlice(events, pageable);
 	}
 
 	private BooleanExpression categoryEqual(Category category) {

--- a/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/repository/EventSearchRepositoryImpl.java
@@ -43,12 +43,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 				.limit(pageSize + 1)
 				.fetch();
 
-		boolean hasNext = events.size() > pageSize;
-		if (hasNext) {
-			events.remove(pageSize);
-		}
-
-		return new SliceImpl<Event>(events, pageable, hasNext);
+		return toSlice(events, pageable);
 	}
 
 	@Override
@@ -71,12 +66,7 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 				.limit(pageSize + 1)
 				.fetch();
 
-		boolean hasNext = events.size() > pageSize;
-		if (hasNext) {
-			events.remove(pageSize);
-		}
-
-		return new SliceImpl<Event>(events, pageable, hasNext);
+		return toSlice(events, pageable);
 	}
 
 	@Override
@@ -135,5 +125,15 @@ public class EventSearchRepositoryImpl implements EventSearchRepository {
 
 		return QEvent.event.eventDate.goe(monthStart)
 				.and(QEvent.event.eventDate.lt(monthEnd));
+	}
+
+	private <T> Slice<T> toSlice(List<T> list, Pageable pageable) {
+		int pageSize = pageable.getPageSize();
+
+		boolean hasNext = list.size() > pageSize;
+
+		if (hasNext) list.remove(pageSize);
+
+		return new SliceImpl<>(list, pageable, hasNext);
 	}
 }

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
@@ -50,6 +50,24 @@ public class EventService {
 		eventRepository.save(eventWriteDto.toEntity(member));
 	}
 
+	public EventListDto getMonthlyEvents(
+			final String memberId,
+			final int page,
+			final String category,
+			final Boolean attended,
+			final int year,
+			final int month
+	) {
+		assertMemberExists(memberId);
+
+		Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+		Slice<Event> result = eventRepository.findMonthlyEventsByMemberIdAndCategoryAndAttentedOrderBy(
+				memberId, year, month, Category.of(category), attended, pageable
+		);
+		return EventListDto.of(result);
+	}
+
 	public EventListDto getEventHistory(
 			final String memberId,
 			final int page,

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
@@ -60,7 +60,7 @@ public class EventService {
 
 		Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
-		Slice<Event> result = eventRepository.findMonthlyEventsByMemberIdAndCategoryAndAttentedOrderBy(
+		Slice<Event> result = eventRepository.findMonthlyEventsByMemberIdAndCategoryAndAttendedOrderBy(
 				memberId,
 				eventSearchRequestDto.year(),
 				eventSearchRequestDto.month(),

--- a/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/event/service/EventService.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.appjam.bongbaek.domain.event.dto.request.CostProposalRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventDeleteRequestDto;
+import org.appjam.bongbaek.domain.event.dto.request.EventSearchRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventUpdateRequestDto;
 import org.appjam.bongbaek.domain.event.dto.request.EventWriteDto;
 import org.appjam.bongbaek.domain.event.dto.response.CostProposalResponseDto;
@@ -53,17 +54,19 @@ public class EventService {
 	public EventListDto getMonthlyEvents(
 			final String memberId,
 			final int page,
-			final String category,
-			final Boolean attended,
-			final int year,
-			final int month
+			final EventSearchRequestDto eventSearchRequestDto
 	) {
 		assertMemberExists(memberId);
 
 		Pageable pageable = PageRequest.of(page, PAGE_SIZE);
 
 		Slice<Event> result = eventRepository.findMonthlyEventsByMemberIdAndCategoryAndAttentedOrderBy(
-				memberId, year, month, Category.of(category), attended, pageable
+				memberId,
+				eventSearchRequestDto.year(),
+				eventSearchRequestDto.month(),
+				Category.of(eventSearchRequestDto.category()),
+				eventSearchRequestDto.attended(),
+				pageable
 		);
 		return EventListDto.of(result);
 	}

--- a/src/main/java/org/appjam/bongbaek/global/exception/handler/common/CommonExceptionHandler.java
+++ b/src/main/java/org/appjam/bongbaek/global/exception/handler/common/CommonExceptionHandler.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
+import jakarta.validation.ConstraintViolationException;
+
 @RestControllerAdvice
 public class CommonExceptionHandler extends BaseExceptionHandler {
 	@ExceptionHandler(NoHandlerFoundException.class)
@@ -52,5 +54,10 @@ public class CommonExceptionHandler extends BaseExceptionHandler {
 	@ExceptionHandler(RequestInvalidException.class)
 	protected ApiResponse handleRequestInvalidException(RequestInvalidException e) {
 		return buildErrorResponse(ErrorCode.REQUEST_CONTENT_INVALID);
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	protected ApiResponse handleConstraintViolationException(ConstraintViolationException e) {
+		return buildErrorResponse(ErrorCode.REQUEST_CONTENT_INVALID, e.getMessage());
 	}
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #90 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 요구사항 변경에 따라 월별 경조사 조회 기능을 구현합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 월별 경조사 정보 조회 기능 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
<img width="745" height="647" alt="스크린샷 2025-11-29 오후 2 55 36" src="https://github.com/user-attachments/assets/2218e435-4985-497a-870c-eba2d3484b30" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 급하게 적용해야 하는 추가 기능이라 빠른 리뷰 부탁드립니다..ㅠㅠ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 월별 경조사 조회 API 추가: 연도·월 기준으로 멤버별 경조사 목록을 조회할 수 있습니다.
  * 월별 조회에 카테고리·참석 여부 필터 및 페이지네이션 지원

* **Improvements**
  * 요청 DTO 기반 검색 파라미터 도입으로 월별 조회 사용성 향상
  * 입력 검증 강화: month 값 범위(1~12) 검사 및 여러 엔드포인트에 유효성 검사 적용
  * 검증 예외에 대한 일관된 오류 응답 처리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->