### PR TITLE
[FEAT] 회원가입, 로그인 로직에 redis 관련 추가

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -77,15 +77,15 @@ public class MemberService {
 	public LoginResponse signUp(
 			final SignUpRequest signUpRequest
 	) {
+        // 이미 가입된 회원인지 확인
+        if (isAlreadyExistsMember(signUpRequest)) {
+            throw new MemberAlreadyExistsException();
+        }
+
         // 최초 로그인에서 검증된 oauthId인지 확인
         if (!oAuthSignUpStore.exists(signUpRequest.oauthProvider(), signUpRequest.oauthId())) {
             throw new MemberNotAuthenticatedException();
         }
-
-        // 이미 가입된 회원인지 확인
-		if (isAlreadyExistsMember(signUpRequest)) {
-			throw new MemberAlreadyExistsException();
-		}
 
 		Member member = memberRepository.save(signUpRequest.toMember());
 		TokenResponse tokenResponse = generateTokensForMember(member);

--- a/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/member/service/MemberService.java
@@ -17,6 +17,7 @@ import org.appjam.bongbaek.global.exception.member.MemberNotFoundException;
 import org.appjam.bongbaek.global.exception.member.TokenInvalidException;
 import org.appjam.bongbaek.global.jwt.JwtBlacklistManager;
 import org.appjam.bongbaek.global.jwt.JwtRefreshStore;
+import org.appjam.bongbaek.global.jwt.OAuthSignUpStore;
 import org.appjam.bongbaek.global.jwt.components.JwtParser;
 import org.appjam.bongbaek.global.jwt.components.JwtProvider;
 import org.appjam.bongbaek.global.jwt.components.JwtValidator;
@@ -41,6 +42,7 @@ public class MemberService {
 	private final MemberWithdrawalRepository memberWithdrawalRepository;
 
 	private final OidcOAuthClient oidcOAuthClient;
+    private final OAuthSignUpStore oAuthSignUpStore;
 
 	private final JwtProvider jwtProvider;
 	private final JwtValidator jwtValidator;
@@ -59,6 +61,8 @@ public class MemberService {
 				OAuthProvider.of(oAuthProvider));
 
 		if (OptionalMember.isEmpty()) {
+            oAuthSignUpStore.save(oAuthProvider, oAuthId);
+
 			return LoginResponse.failure(oAuthProvider, oAuthId);
 		}
 
@@ -73,13 +77,21 @@ public class MemberService {
 	public LoginResponse signUp(
 			final SignUpRequest signUpRequest
 	) {
-		// 여기서 최초 로그인 시 redis에 저장한 소셜로그인 아이디를 조회해서 올바른 아이디인지 검증 필요
+        // 최초 로그인에서 검증된 oauthId인지 확인
+        if (!oAuthSignUpStore.exists(signUpRequest.oauthProvider(), signUpRequest.oauthId())) {
+            throw new MemberNotAuthenticatedException();
+        }
+
+        // 이미 가입된 회원인지 확인
 		if (isAlreadyExistsMember(signUpRequest)) {
 			throw new MemberAlreadyExistsException();
 		}
 
 		Member member = memberRepository.save(signUpRequest.toMember());
 		TokenResponse tokenResponse = generateTokensForMember(member);
+
+        // 가입 완료 후, redis에서 oauthId 제거
+        oAuthSignUpStore.delete(signUpRequest.oauthProvider(), signUpRequest.oauthId());
 
 		log.info("회원가입 완료. {} ID: {}", signUpRequest.oauthProvider(), signUpRequest.oauthId());
 

--- a/src/main/java/org/appjam/bongbaek/global/jwt/OAuthSignUpStore.java
+++ b/src/main/java/org/appjam/bongbaek/global/jwt/OAuthSignUpStore.java
@@ -1,0 +1,56 @@
+package org.appjam.bongbaek.global.jwt;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 최초 소셜 로그인 시 OIDC 검증이 끝난 oauthId를
+ * 회원가입 직전까지 잠시 보관하는 Redis 저장소.
+ * - key 형식: signup:oauth:{provider}:{oauthId}
+ *   예) signup:oauth:kakao:1234567890
+ */
+@Component
+@RequiredArgsConstructor
+public class OAuthSignUpStore {
+
+    private static final String PREFIX = "signup:oauth:";
+
+    // 최초 로그인 후 회원가입을 진행해야 하는 oauthId 유효 시간(초)
+    private static final long DEFAULT_TTL_SECONDS = 10 * 60; // 10분
+
+    private final StringRedisTemplate redis;
+
+    private String key(String provider, String oauthId) {
+        return PREFIX + provider + ":" + oauthId;
+    }
+
+    /**
+     * 기본 TTL(10분)로 oauthId 저장
+     */
+    public void save(String provider, String oauthId) {
+        save(provider, oauthId, DEFAULT_TTL_SECONDS);
+    }
+
+    /**
+     * 지정한 TTL(초)로 oauthId 저장
+     */
+    public void save(String provider, String oauthId, long ttlSeconds) {
+        redis.opsForValue().set(key(provider, oauthId), "1", Math.max(1, ttlSeconds), TimeUnit.SECONDS);
+    }
+
+    /**
+     * 해당 provider + oauthId 조합이 최초 로그인에서 검증된 상태로 Redis에 저장돼 있는지 확인
+     */
+    public boolean exists(String provider, String oauthId) {
+        return Boolean.TRUE.equals(redis.hasKey(key(provider, oauthId)));
+    }
+
+    /**
+     * 회원가입이 정상적으로 끝난 oauthId는 재사용 방지 + 메모리 정리를 위해 제거
+     */
+    public void delete(String provider, String oauthId) {
+        redis.delete(key(provider, oauthId));
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #84 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 최초 로그인시 redis에 해당 oauthid, oauthprovider를 저장하고 TTL 내 회원가입시 검증된 oauthid인지 검사하는 부분을 추가하였습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] OAuthSignUpStore 작성
- [x] 로그인 로직에 최초 로그인시 redis에 key 저장 로직 추가
- [x] 회원가입 로직에 최초 로그인 시 검증된 oauthid인지 검사하는 부분 추가

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 
<img width="673" height="197" alt="image" src="https://github.com/user-attachments/assets/be9e7f43-abb3-47d5-bb41-0db329504e34" />
<img width="469" height="336" alt="image" src="https://github.com/user-attachments/assets/81be77b4-7c75-4c82-9b5f-9c2798dabda8" />

해당 로직에 "ss" 로그 찍히도록 임시로 추가한 다음, 해당 케이스에 대해 로그와 예외가 출력되는 것을 확인하였습니다.

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- OAuthSignUpStore 에 주석을 많이 추가해두었는데, 혹시 빼는 것이 좀 더 낫다면 최소한만 남기고 모두 제거하겠습니다!
- TTL에 대해서 임의로 10분으로 설정해두었습니다! 이 부분에 대해 혹시 더 나은 설정이 있다면 알려주시면 감사하겠습니다 🙇‍♀️🫡

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 소셜 로그인 가입 프로세스의 안정성 개선: OAuth 인증 정보를 임시 보관하여 가입 완료 시까지 유지합니다.
  * OAuth 가입 상태 검증 강화: 이전에 등록된 OAuth 정보만 가입을 진행할 수 있도록 확인합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->