### PR TITLE
[REFAC] 카테고리 검색, queryDSL로 수정

### DIFF
--- a/src/main/java/org/appjam/bongbaek/domain/content/repository/ContentRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/content/repository/ContentRepository.java
@@ -1,22 +1,15 @@
 package org.appjam.bongbaek.domain.content.repository;
 
 import org.appjam.bongbaek.domain.content.entity.Content;
-import org.appjam.bongbaek.domain.event.entity.Category;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface ContentRepository extends JpaRepository<Content, String> {
+public interface ContentRepository extends JpaRepository<Content, String>, ContentSearchRepository {
     @Query("select a from Content a join fetch a.contentImages where a.contentId = :contentId")
     Optional<Content> findContentByIdWithImages(String contentId);
 
     List<Content> findTop3ByOrderByCreatedDateTimeDesc();
-
-    Page<Content> findAllByOrderByCreatedDateTimeDesc(Pageable pageable);
-
-    Page<Content> findContentsByContentCategoryOrderByCreatedDateTimeDesc(Category category, Pageable pageable);
 }

--- a/src/main/java/org/appjam/bongbaek/domain/content/repository/ContentSearchRepository.java
+++ b/src/main/java/org/appjam/bongbaek/domain/content/repository/ContentSearchRepository.java
@@ -1,0 +1,11 @@
+package org.appjam.bongbaek.domain.content.repository;
+
+import org.appjam.bongbaek.domain.content.entity.Content;
+import org.appjam.bongbaek.domain.event.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ContentSearchRepository {
+
+    Page<Content> findContentsByCategoryOrderByCreatedDateDesc(Category category, Pageable pageable);
+}

--- a/src/main/java/org/appjam/bongbaek/domain/content/repository/ContentSearchRepositoryImpl.java
+++ b/src/main/java/org/appjam/bongbaek/domain/content/repository/ContentSearchRepositoryImpl.java
@@ -1,0 +1,51 @@
+package org.appjam.bongbaek.domain.content.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.appjam.bongbaek.domain.content.entity.Content;
+import org.appjam.bongbaek.domain.content.entity.QContent;
+import org.appjam.bongbaek.domain.event.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ContentSearchRepositoryImpl implements ContentSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QContent qContent = QContent.content;
+
+    @Override
+    public Page<Content> findContentsByCategoryOrderByCreatedDateDesc(Category category, Pageable pageable) {
+
+        List<Content> contents = queryFactory.selectFrom(qContent)
+                .where(categoryEqual(category))
+                .orderBy(qContent.createdDateTime.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory.select(qContent.count())
+                .from(qContent)
+                .where(categoryEqual(category))
+                .fetchOne();
+
+        if(totalCount == null) {
+            totalCount = 0L;
+        }
+
+        return new PageImpl<>(contents, pageable, totalCount);
+    }
+
+    private BooleanExpression categoryEqual(Category category) {
+        if(category == null){
+            return null;
+        }
+        return QContent.content.contentCategory.eq(category);
+    }
+}

--- a/src/main/java/org/appjam/bongbaek/domain/content/service/ContentService.java
+++ b/src/main/java/org/appjam/bongbaek/domain/content/service/ContentService.java
@@ -1,6 +1,7 @@
 package org.appjam.bongbaek.domain.content.service;
 
 import lombok.RequiredArgsConstructor;
+import org.appjam.bongbaek.domain.common.OwnerType;
 import org.appjam.bongbaek.domain.content.dto.request.ContentWriteDto;
 import org.appjam.bongbaek.domain.content.dto.response.ContentDetailResponseDto;
 import org.appjam.bongbaek.domain.content.dto.response.ContentHomeResponseDto;
@@ -9,7 +10,6 @@ import org.appjam.bongbaek.domain.content.entity.Content;
 import org.appjam.bongbaek.domain.content.entity.ContentImage;
 import org.appjam.bongbaek.domain.content.repository.ContentRepository;
 import org.appjam.bongbaek.domain.event.entity.Category;
-import org.appjam.bongbaek.domain.common.OwnerType;
 import org.appjam.bongbaek.global.exception.common.RequestInvalidException;
 import org.appjam.bongbaek.global.exception.content.ContentNotFoundException;
 import org.appjam.bongbaek.global.exception.image.ImageNotFoundException;
@@ -51,16 +51,12 @@ public class ContentService {
     @Transactional(readOnly = true)
     public ContentListDto getContentList(int page, String category) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Page<Content> contents = contentRepository.findContentsByCategoryOrderByCreatedDateDesc(
+                Category.of(category),
+                pageable
+        );
 
-        Category contentCategory = Category.of(category);
-
-        if (contentCategory == null) {
-            Page<Content> allContents = contentRepository.findAllByOrderByCreatedDateTimeDesc(pageable);
-            return ContentListDto.of(allContents);
-        }
-
-        Page<Content> categoryContents = contentRepository.findContentsByContentCategoryOrderByCreatedDateTimeDesc(contentCategory, pageable);
-        return ContentListDto.of(categoryContents);
+        return ContentListDto.of(contents);
     }
 
     @Transactional
@@ -81,7 +77,7 @@ public class ContentService {
             content.addContentImage(thumbnail);
 
         } catch (Exception e) {
-            if(thumbnailDto != null) {
+            if (thumbnailDto != null) {
                 fileUploader.delete(thumbnailDto.storageKey());
             }
             throw new RequestInvalidException();
@@ -106,7 +102,7 @@ public class ContentService {
             content.getContentImages().remove(oldThumbnail);
 
         } catch (Exception e) {
-            if(newThumbnailDto != null) {
+            if (newThumbnailDto != null) {
                 fileUploader.delete(newThumbnailDto.storageKey());
             }
             throw new RequestInvalidException();
@@ -115,18 +111,18 @@ public class ContentService {
     }
 
     @Transactional
-    public void uploadMainImages(String contentId, List<MultipartFile> newImageFiles){
+    public void uploadMainImages(String contentId, List<MultipartFile> newImageFiles) {
         Content content = contentRepository.findContentByIdWithImages(contentId)
                 .orElseThrow(ContentNotFoundException::new);
 
         List<String> storedKeys = new ArrayList<>();
-        for(MultipartFile newImageFile : newImageFiles) {
+        for (MultipartFile newImageFile : newImageFiles) {
             try {
                 String storedKey = uploadMainImage(content, newImageFile);
                 storedKeys.add(storedKey);
 
-            } catch (Exception e){
-                for(String storedKey : storedKeys) {
+            } catch (Exception e) {
+                for (String storedKey : storedKeys) {
                     fileUploader.delete(storedKey);
                 }
                 throw new RequestInvalidException();


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #94 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- eventSearchRepositoryImpl의 카테고리 검색과 유사하게 queryDSL 생성

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] contentSearchRepositoryImpl에 카테고리 검색 메서드 추가
- [x] contentService에서 getContentList 메서드 수정

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 확인 완료입니다~

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- Lint 설정했더니 이것저것 수정됐네요. 다음에는 끄고 커밋하겠습니다..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 콘텐츠 검색 및 필터링 기능을 개선했습니다.
  * 카테고리 기반 콘텐츠 조회 로직을 최적화했습니다.
  * 페이지네이션을 통한 효율적인 콘텐츠 로드를 지원합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->